### PR TITLE
Add working Haah cubic codes

### DIFF
--- a/_0.helpers_and_metadata/code_metadata.jl
+++ b/_0.helpers_and_metadata/code_metadata.jl
@@ -2,6 +2,7 @@ module CodeMetadata
 
 using QuantumClifford
 using QuantumClifford.ECC
+import Hecke
 import PyQDecoders
 import LDPCDecoders
 
@@ -85,6 +86,14 @@ const code_metadata = Dict(
         :errrange => (eᵐⁱⁿ, eᵐᵃˣ, steps),
         :description => "My friend Nithin made this one. It is here as an example placeholder as we built out the page for this code family.",
         :redundantrows => true,
+    ),
+    haah_cubic_codes => Dict(
+        :family => [([0, 15, 20, 28, 66], [0, 58, 59, 100, 121], 6)],
+        :decoders => [TableDecoder],
+        :setups => [CommutationCheckECCSetup],
+        :ecczoo => "https://errorcorrectionzoo.org/c/haah_cubic",
+        :errrange => (eᵐⁱⁿ, eᵐᵃˣ, steps),
+        :description => "The Haah cubic code to protect against simultaneous independent Pauli errors on different sites."
     ),
 )
 

--- a/_0.helpers_and_metadata/helpers.jl
+++ b/_0.helpers_and_metadata/helpers.jl
@@ -18,6 +18,8 @@ function instancenameof(x)
             end
         end
     end
+    # Bad fix to prevent ENAMETOOLONG on LPCodes
+    str = first(str,254)
     str *= ")"
     return str
 end

--- a/_0.helpers_and_metadata/helpers.jl
+++ b/_0.helpers_and_metadata/helpers.jl
@@ -19,7 +19,7 @@ function instancenameof(x)
         end
     end
     # Bad fix to prevent ENAMETOOLONG on LPCodes
-    str = first(str,254)
+    str = first(str,20)
     str *= ")"
     return str
 end

--- a/_2.markdown_generation_pass/figures.jl
+++ b/_2.markdown_generation_pass/figures.jl
@@ -99,7 +99,7 @@ function prep_figures(code_metadata)
         # Plotting benchmarking summary fig
         f = make_decoder_figure(e, r;
             title="$(codetypename)",
-            codelabels=instancenameof.(codes),
+            codelabels=first(instancenameof.(codes),20),
             decoderlabels=skipredundantfix.(decoders),
             setuplabels=skipredundantfix.(setups),
             single_error

--- a/_2.markdown_generation_pass/figures.jl
+++ b/_2.markdown_generation_pass/figures.jl
@@ -99,7 +99,7 @@ function prep_figures(code_metadata)
         # Plotting benchmarking summary fig
         f = make_decoder_figure(e, r;
             title="$(codetypename)",
-            codelabels=first(instancenameof.(codes),20),
+            codelabels=instancenameof.(codes),
             decoderlabels=skipredundantfix.(decoders),
             setuplabels=skipredundantfix.(setups),
             single_error


### PR DESCRIPTION
- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

The main issue that I kept running into was around how the haah cubic code (and I assume other LPCodes) work with instancenameof in Helpers. The name was upwards of 1000 bytes and caused ENAMETOOLONG when trying to create the file and pushed the graph off the image when plotting. I made a quick fix to truncate the name to a reasonable maximum length, but I want to look into how the function works with other ext QuantumClifford codes and see if I can come up with a better solution.