### PR TITLE
Db concurrency fix

### DIFF
--- a/_0.helpers_and_metadata/db_helpers.jl
+++ b/_0.helpers_and_metadata/db_helpers.jl
@@ -7,18 +7,21 @@ using ..Helpers: logrange, instancenameof, skipredundantprefix, typenameof
 
 const CONN = Ref{Union{Nothing, SQLite.DB}}(nothing)
 const DB_PATH = Ref("codes/")
+const DB_FILENAME = Ref("results.sqlite")
 
 function init_db!(path=DB_PATH[]; filename="results.sqlite") # path should be a directory, not a file
     file_path = joinpath(path, filename) # path/filename
-    if CONN[] !== nothing && path == DB_PATH[]
-        return CONN[] # already initialized with the same path 
+    if CONN[] !== nothing && path == DB_PATH[] && filename == DB_FILENAME[]
+        return CONN[] # already initialized with the same database
     end
     if CONN[] !== nothing
         DBInterface.close!(CONN[]) # close existing connection if path changes
+        CONN[] = nothing
     end
-    isdir(path) || mkdir(path)
+    mkpath(path)
     CONN[] = DBInterface.connect(SQLite.DB, file_path)
     DB_PATH[] = path
+    DB_FILENAME[] = filename
     SQLite.busy_timeout(CONN[], 100)
     DBInterface.execute(
         CONN[],
@@ -30,14 +33,14 @@ function init_db!(path=DB_PATH[]; filename="results.sqlite") # path should be a 
     return CONN[]
 end
 
-init_db!()
+db() = isnothing(CONN[]) ? init_db!() : CONN[]
 
 function dbrow(code, decoder, setup, e)
     coden = skipredundantprefix(instancenameof(code))
     decodern = skipredundantprefix(decoder)
     setupn = skipredundantprefix(setup)
     res = DBInterface.execute(
-        CONN[],
+        db(),
         "SELECT * FROM results WHERE code=? AND decoder=? AND setup=? AND error=?",
         (coden, decodern, setupn, e))
     isempty(res) ? nothing : first(res)
@@ -72,7 +75,8 @@ function dbrow!(code, decoder, setup, e, n, lx, lz)
     setupn = skipredundantprefix(setup)
     while true # retry on sqlite busy
         try
-            newrow = DBInterface.transaction(CONN[]) do
+            conn = db()
+            newrow = DBInterface.transaction(conn) do
                 old = dbrow(code, decoder, setup, e)
                 newn, newlx, newlz = if isnothing(old)
                     n, lx, lz
@@ -82,7 +86,7 @@ function dbrow!(code, decoder, setup, e, n, lx, lz)
                 end
                 newrow = coden, decodern, setupn, e, newn, newlx, newlz
                 DBInterface.execute(
-                    CONN[],
+                    conn,
                     "REPLACE INTO results (code, decoder, setup, error, nsamples, logx, logz) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     newrow
                 )

--- a/_0.helpers_and_metadata/db_helpers.jl
+++ b/_0.helpers_and_metadata/db_helpers.jl
@@ -23,13 +23,13 @@ function init_db!(path=DB_PATH[]; filename="results.sqlite") # path should be a 
     DB_PATH[] = path
     DB_FILENAME[] = filename
     SQLite.busy_timeout(CONN[], 100)
-    DBInterface.execute(
+    collect(DBInterface.execute(
         CONN[],
         """CREATE TABLE IF NOT EXISTS results
         (code TEXT, decoder TEXT, setup TEXT, error REAL, nsamples INTEGER, logx REAL, logz REAL,
             PRIMARY KEY (code, decoder, setup, error))"""
-    )
-    DBInterface.execute(CONN[], "PRAGMA journal_mode=WAL")
+    ))
+    collect(DBInterface.execute(CONN[], "PRAGMA journal_mode=WAL"))
     return CONN[]
 end
 
@@ -43,7 +43,23 @@ function dbrow(code, decoder, setup, e)
         db(),
         "SELECT * FROM results WHERE code=? AND decoder=? AND setup=? AND error=?",
         (coden, decodern, setupn, e))
-    isempty(res) ? nothing : first(res)
+    try
+        if isempty(res)
+            return nothing
+        end
+        row = first(res)
+        return (
+            code=row.code,
+            decoder=row.decoder,
+            setup=row.setup,
+            error=row.error,
+            nsamples=row.nsamples,
+            logx=row.logx,
+            logz=row.logz,
+        )
+    finally
+        DBInterface.close!(res)
+    end
 end
 
 function dbnarray(codes, decoders, setups, errors)
@@ -76,23 +92,26 @@ function dbrow!(code, decoder, setup, e, n, lx, lz)
     while true # retry on sqlite busy
         try
             conn = db()
-            newrow = DBInterface.transaction(conn) do
-                old = dbrow(code, decoder, setup, e)
-                newn, newlx, newlz = if isnothing(old)
-                    n, lx, lz
-                else
-                    newn = n + old.nsamples
-                    newn, (lx * n + old.logx * old.nsamples) / newn, (lz * n + old.logz * old.nsamples) / newn
-                end
-                newrow = coden, decodern, setupn, e, newn, newlx, newlz
-                DBInterface.execute(
-                    conn,
-                    "REPLACE INTO results (code, decoder, setup, error, nsamples, logx, logz) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    newrow
-                )
-                newrow
-            end
-            return newrow
+            collect(DBInterface.execute(
+                conn,
+                """
+                INSERT INTO results (code, decoder, setup, error, nsamples, logx, logz)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(code, decoder, setup, error) DO UPDATE SET
+                    nsamples = results.nsamples + excluded.nsamples,
+                    logx = (
+                        results.logx * results.nsamples +
+                        excluded.logx * excluded.nsamples
+                    ) / (results.nsamples + excluded.nsamples),
+                    logz = (
+                        results.logz * results.nsamples +
+                        excluded.logz * excluded.nsamples
+                    ) / (results.nsamples + excluded.nsamples)
+                """,
+                (coden, decodern, setupn, e, n, lx, lz),
+            ))
+            row = dbrow(code, decoder, setup, e)
+            return row.code, row.decoder, row.setup, row.error, row.nsamples, row.logx, row.logz
         catch e
             if e == SQLite.SQLiteException("database is locked")
                 @debug "Database locked, retrying..."


### PR DESCRIPTION
# Fix DB Concurrency Problem when Running Parallel Tasks
The previous approach of DB R/W introduces conflicts when running large scale parallel evaluations (e.g. on Slurm clusters), mainly because of unfinished active SQL statements and simultaneous attempts to read.

## Fix
- Force finalize active statements with collect()
- Avoid initializing DB by default, only initialize when necessary
- Explicitly close DB statements after querying
- Use UPSERT to avoid chaining multiple active statements that previous SQLite statements could be left active when the transaction was opened.

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>