### PR TITLE
58 reliable slurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ julia> include("wiki_database_passes.jl")
 julia> run_evaluations(CodeMetadata.code_metadata)
 ```
 
-If you want to run only some codes, e.g. the code family `CodeType`, you can use `run_evaluations(code_metadata; include=[CodeType])`.
+If you want to run only some code families, e.g. the code family `CodeType`, you can use `run_evaluations(code_metadata; include=[CodeType])`.
+
+If you want to run only some instances within a code family, use `code_instances`. Filters can use the metadata argument tuple or the display name:
+
+```julia
+run_evaluations(code_metadata; include=[TwoBlockGroupAlgebra], code_instances=[(:A1, :B1)])
+run_evaluations(code_metadata; include=[TwoBlockGroupAlgebra], code_instances=["TwoBlockGroupAlgebra(A1, B1)"])
+```
 
 If you want to run only some decoders or setups, use `decoders` or `setups` filters. Filters can use the exact metadata entries or their display names:
 
@@ -101,11 +108,13 @@ Running the benchmarks on a Slurm cluster can be more efficient if you want to p
 ### Running Benchmarks
 1. Run the Slurm entrypoint from the repository root. It writes a run manifest under `runs/slurm/<run_id>/`, assigns one manifest-owned database filename per task, and passes those filenames into `run_evaluations`.
 
+    The current Slurm script keeps light code families batched by `family + decoder + setup`, and splits heavy code families by `family + code_instance + decoder + setup`. This keeps small tasks from creating unnecessary scheduler overhead while making the expensive heavy tasks easier to balance and retry.
+
     ```bash
-    sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
+    sbatch -N 3 -n 9 -t 06:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
     ```
 
-    After all task phases finish, inspect `runs/slurm/<run_id>/summary.toml` for the run-level succeeded, failed, incomplete, and missing-status task lists.
+    After all task phases finish, inspect `runs/slurm/<run_id>/summary.toml` for the run-level succeeded, failed, incomplete, and missing-status task lists. The timing summary includes duration grouped by family, code instance, decoder, and setup.
 
     For custom scripts, pass an explicit database directory and filename when you want a run to write to a specific SQLite file:
 

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Running the benchmarks on a Slurm cluster can be more efficient if you want to p
     ```julia
     run_evaluations(CodeMetadata.code_metadata; db_path="path/to/results", db_filename="db_task.sqlite")
     ```
-2. To merge your results from multiple runs, you can use the `join_results` function from the `DBJoinHelper` module. This function takes a directory containing multiple SQLite databases and merges them into a single database. For example:
+2. To merge one Slurm run's per-task databases into a single run-level database, pass the run directory to the Slurm results script:
 
-    ```julia
-    include("_0.helpers_and_metadata/db_join_helper.jl")
-    using .DBJoinHelper: join_results
-    join_results("path/to/results"; output_path="path/to/merged_results.sqlite")
+    ```bash
+    julia --project=. script/slurm/get_results.jl runs/slurm/<run_id>
     ```
+
+    This reads `runs/slurm/<run_id>/db/*.sqlite` and writes `runs/slurm/<run_id>/results.sqlite`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ julia> run_evaluations(CodeMetadata.code_metadata)
 
 If you want to run only some codes, e.g. the code family `CodeType`, you can use `run_evaluations(code_metadata; include=[CodeType])`.
 
+If you want to run only some decoders or setups, use `decoders` or `setups` filters. Filters can use the exact metadata entries or their display names:
+
+```julia
+run_evaluations(code_metadata; include=[CodeType], decoders=[TableDecoder])
+run_evaluations(code_metadata; include=[CodeType], decoders=["Table"], setups=["CommutationCheck"])
+```
+
 Optionally, if you want to specify a location (directory) for the generated database, you can use `run_evaluations(code_metadata; db_path="path/to/database")`.
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ julia> run_evaluations(CodeMetadata.code_metadata)
 
 If you want to run only some codes, e.g. the code family `CodeType`, you can use `run_evaluations(code_metadata; include=[CodeType])`.
 
-Optionally, if you want to specify a location (directory) for the generated database, you can use `run_evaluations(code_metadata; database_path="path/to/database")`.
+Optionally, if you want to specify a location (directory) for the generated database, you can use `run_evaluations(code_metadata; db_path="path/to/database")`.
 
 
 ## To merge evaluation results from multiple runs
@@ -92,9 +92,16 @@ Running the benchmarks on a Slurm cluster can be more efficient if you want to p
     ```
 
 ### Running Benchmarks
-1. You can create a Julia script that runs the benchmarks for a specific set of codes and decoders as submit it as a Slurm job. In your script, you can call `run_evaluations` with the appropriate parameters to specify the output directory and set `worker_db` to `true` so the results are written to the database from each worker process. For example:
+1. Run the Slurm entrypoint from the repository root. It writes a run manifest under `runs/slurm/<run_id>/`, assigns one manifest-owned database filename per task, and passes those filenames into `run_evaluations`.
+
+    ```bash
+    sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
+    ```
+
+    For custom scripts, pass an explicit database directory and filename when you want a run to write to a specific SQLite file:
+
     ```julia
-    run_evaluations(CodeMetadata.code_metadata; output_path="path/to/results", worker_db=true)`
+    run_evaluations(CodeMetadata.code_metadata; db_path="path/to/results", db_filename="db_task.sqlite")
     ```
 2. To merge your results from multiple runs, you can use the `join_results` function from the `DBJoinHelper` module. This function takes a directory containing multiple SQLite databases and merges them into a single database. For example:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Running the benchmarks on a Slurm cluster can be more efficient if you want to p
     sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
     ```
 
+    After all task phases finish, inspect `runs/slurm/<run_id>/summary.toml` for the run-level succeeded, failed, incomplete, and missing-status task lists.
+
     For custom scripts, pass an explicit database directory and filename when you want a run to write to a specific SQLite file:
 
     ```julia

--- a/_0.helpers_and_metadata/slurm_helper.jl
+++ b/_0.helpers_and_metadata/slurm_helper.jl
@@ -1,7 +1,0 @@
-using Random
-using UUIDs
-
-function generate_unique_name()
-    uuid = string(uuid4())
-    return "db_$uuid.sqlite"
-end

--- a/script/slurm/get_results.jl
+++ b/script/slurm/get_results.jl
@@ -1,0 +1,39 @@
+#! /usr/bin/env julia
+
+using Pkg
+
+const REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+
+Pkg.activate(REPO_ROOT)
+
+include(joinpath(REPO_ROOT, "_0.helpers_and_metadata/db_join_helper.jl"))
+
+using .DBJoinHelper: join_results
+
+function usage()
+    script = basename(PROGRAM_FILE)
+    return "Usage: julia --project=. script/slurm/$(script) <run_dir>"
+end
+
+function sqlite_files(dir)
+    return filter(f -> isfile(f) && endswith(lowercase(f), ".sqlite"), readdir(dir; join=true))
+end
+
+function main(args)
+    if length(args) != 1
+        error(usage())
+    end
+
+    run_dir = abspath(only(args))
+    db_dir = joinpath(run_dir, "db")
+    output_path = joinpath(run_dir, "results.sqlite")
+
+    isdir(run_dir) || error("Slurm run directory does not exist: $(run_dir)")
+    isdir(db_dir) || error("Slurm run database directory does not exist: $(db_dir)")
+    isempty(sqlite_files(db_dir)) && error("No .sqlite files found in Slurm run database directory: $(db_dir)")
+
+    result_path = join_results(db_dir; output_path=output_path)
+    println("Wrote merged Slurm results to $(result_path)")
+end
+
+main(ARGS)

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -1,38 +1,37 @@
-#!/usr/bin/env julia
+#! /usr/bin/env julia
+
+# This is the working version of our script
 
 # Run with a command like:
 # sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
-#
-# Edit the config block below for each run. Each task calls run_evaluations for
-# one code family and lets the existing project helpers create result files.
+# Should be run from repo root!
 
-const REPO_ROOT = pwd()
-const SLURM_SCRIPT_DIR = joinpath(REPO_ROOT, "script", "slurm")
+# Do instatiate in julia REPL
+# ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
 
 using Pkg
-Pkg.activate(REPO_ROOT)
-cd(REPO_ROOT)
 
-using Dates
+Pkg.activate(pwd())
+
 using Distributed
 using SlurmClusterManager
-using TOML
 
-include(joinpath(SLURM_SCRIPT_DIR, "slurm_manifest_generator.jl"))
-include(joinpath(REPO_ROOT, "_0.helpers_and_metadata", "db_join_helper.jl"))
+addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
-using .SlurmManifestGenerator: ManifestConfig, build_manifest, write_manifest_file
-using .DBJoinHelper: join_results
+@info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
 
-# ---------------------------------------------------------------------------
-# Runner config
-# ---------------------------------------------------------------------------
+@everywhere begin
+    include(joinpath(pwd(), "wiki_database_passes.jl"))
 
-const RUN_ROOT = "runs/slurm"
-const RUN_ID = "" # Empty means use a timestamp-based run id.
-const ALLOW_OVERWRITE = false
+    function run_task(task_name::Symbol)
+        task = getproperty(CodeMetadata, task_name)
+        @info "Running task: $task_name on $(myid())"
+        run_evaluations(CodeMetadata.code_metadata; include=[task], db_path=joinpath(pwd(), "codes/slurm_task_06_24/"), worker_db=true)
+        return "Result for $(task_name)"
+    end
+end
 
-const INCLUDE_FAMILIES = [
+const LIGHT_TASKS = [
     :Gottesman,
     :Toric,
     :Shor9,
@@ -40,236 +39,19 @@ const INCLUDE_FAMILIES = [
     :Perfect5,
     :Cleve8,
     :Surface,
+]
+
+const HEAVY_TASKS = [
     :GeneralizedBicycle,
     :TwoBlockGroupAlgebra,
     :Triangular488,
     :Triangular666,
 ]
 
-const MERGE_SUCCESSFUL_DBS = true
-const WRITE_FAILURE_REPORT = true
+light_results = pmap(run_task, LIGHT_TASKS)
 
-# ---------------------------------------------------------------------------
-# Runner helpers
-# ---------------------------------------------------------------------------
+const HEAVY_WORKER_COUNT = 1
+heavy_pool = WorkerPool(workers()[1:min(HEAVY_WORKER_COUNT, nworkers())])
+heavy_results = pmap(run_task, heavy_pool, HEAVY_TASKS)
 
-timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
-resolve_run_root(path) = isabspath(path) ? path : joinpath(REPO_ROOT, path)
-
-function write_toml_file(path, data)
-    mkpath(dirname(path))
-    open(path, "w") do io
-        TOML.print(io, data)
-    end
-    return path
-end
-
-function build_run_manifest()
-    project = SlurmManifestGenerator.load_project_metadata(REPO_ROOT)
-    config = ManifestConfig(
-        run_root=resolve_run_root(RUN_ROOT),
-        run_id=isempty(RUN_ID) ? nothing : RUN_ID,
-        include_families=copy(INCLUDE_FAMILIES),
-        allow_overwrite=ALLOW_OVERWRITE,
-    )
-
-    manifest = build_manifest(
-        project.code_metadata,
-        config;
-        repo_root=REPO_ROOT,
-        family_name_fn=project.family_name_fn,
-    )
-    manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
-    println("Wrote Slurm run manifest: $manifest_path")
-    println("Planned family tasks: $(length(manifest["tasks"]))")
-    return manifest
-end
-
-function load_worker_code!()
-    remotecall_eval(Main, workers(), :(using Dates))
-    remotecall_eval(Main, workers(), :(using TOML))
-
-    @everywhere begin
-        cd($REPO_ROOT)
-        include(joinpath($REPO_ROOT, "wiki_database_passes.jl"))
-
-        function slurm_timestamp_utc(t=now(UTC))
-            return Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
-        end
-
-        function slurm_sqlite_files(dir)
-            isdir(dir) || return String[]
-            files = filter(path -> isfile(path) && endswith(lowercase(path), ".sqlite"), readdir(dir; join=true))
-            return sort(files)
-        end
-
-        function slurm_write_toml_file(path, data)
-            mkpath(dirname(path))
-            open(path, "w") do io
-                TOML.print(io, data)
-            end
-            return path
-        end
-
-        function slurm_family_from_task(task)
-            for family in keys(CodeMetadata.code_metadata)
-                string(Helpers.typenameof(family)) == task["family"] && return family
-            end
-            error("unknown code family in manifest task: $(task["family"])")
-        end
-
-        function slurm_task_summary(task)
-            return Dict{String,Any}(
-                "id" => task["id"],
-                "task_index" => task["task_index"],
-                "family" => task["family"],
-                "family_symbol" => task["family_symbol"],
-            )
-        end
-
-        function run_slurm_manifest_task(task)
-            artifacts = task["artifacts"]
-            db_dir = artifacts["db_dir"]
-            log_path = artifacts["log"]
-            status_path = artifacts["status"]
-            started_time = time()
-
-            status = Dict{String,Any}(
-                "id" => task["id"],
-                "state" => "running",
-                "worker" => myid(),
-                "started_at" => slurm_timestamp_utc(),
-                "task" => slurm_task_summary(task),
-                "artifacts" => artifacts,
-                "sqlite_files" => String[],
-            )
-
-            try
-                family = slurm_family_from_task(task)
-                mkpath(db_dir)
-                mkpath(dirname(log_path))
-
-                open(log_path, "w") do log_io
-                    redirect_stdout(log_io) do
-                        redirect_stderr(log_io) do
-                            println("Starting task $(task["id"]) for $(task["family"]) on worker $(myid()) at $(status["started_at"])")
-                            run_evaluations(
-                                CodeMetadata.code_metadata;
-                                include=[family],
-                                db_path=db_dir,
-                                worker_db=true,
-                            )
-                            println("Finished task $(task["id"]) at $(slurm_timestamp_utc())")
-                        end
-                    end
-                end
-                status["state"] = "success"
-            catch err
-                error_text = sprint(showerror, err, catch_backtrace())
-                status["state"] = "failed"
-                status["exception"] = error_text
-
-                try
-                    mkpath(dirname(log_path))
-                    open(log_path, "a") do log_io
-                        println(log_io)
-                        println(log_io, "Task $(task["id"]) failed at $(slurm_timestamp_utc())")
-                        println(log_io, error_text)
-                    end
-                catch log_err
-                    status["log_write_exception"] = sprint(showerror, log_err, catch_backtrace())
-                end
-            end
-
-            status["sqlite_files"] = slurm_sqlite_files(db_dir)
-            status["finished_at"] = slurm_timestamp_utc()
-            status["elapsed_seconds"] = time() - started_time
-            slurm_write_toml_file(status_path, status)
-            return status
-        end
-    end
-    return nothing
-end
-
-function stage_successful_dbs(statuses, stage_dir)
-    if isdir(stage_dir)
-        rm(stage_dir; recursive=true)
-    end
-    mkpath(stage_dir)
-
-    staged = String[]
-    for status in statuses
-        get(status, "state", "") == "success" || continue
-        for source in get(status, "sqlite_files", String[])
-            destination = joinpath(stage_dir, "$(status["id"])__$(basename(source))")
-            try
-                symlink(source, destination)
-            catch
-                cp(source, destination; force=true)
-            end
-            push!(staged, destination)
-        end
-    end
-    return staged
-end
-
-function merge_successful_dbs(statuses, successful_db_dir, output_path)
-    staged = stage_successful_dbs(statuses, successful_db_dir)
-    if isempty(staged)
-        println("No successful task databases to merge.")
-        return nothing
-    end
-
-    merged_path = join_results(successful_db_dir; output_path=output_path)
-    println("Merged $(length(staged)) successful task database(s) into $merged_path")
-    return merged_path
-end
-
-function write_failure_report(statuses, path)
-    failures = [status for status in statuses if get(status, "state", "") != "success"]
-    report = Dict{String,Any}(
-        "generated_at" => timestamp_utc(),
-        "failed_count" => length(failures),
-        "failures" => [
-            Dict{String,Any}(
-                "id" => status["id"],
-                "state" => status["state"],
-                "worker" => get(status, "worker", ""),
-                "task" => status["task"],
-                "artifacts" => status["artifacts"],
-                "sqlite_files" => get(status, "sqlite_files", String[]),
-                "exception" => get(status, "exception", ""),
-            )
-            for status in failures
-        ],
-    )
-    write_toml_file(path, report)
-    println("Wrote failure report: $path ($(length(failures)) failure(s))")
-    return path
-end
-
-function main()
-    manifest = build_run_manifest()
-    paths = manifest["artifacts"]
-
-    addprocs(SlurmManager(), exeflags="--project=$(REPO_ROOT)")
-    @info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
-
-    load_worker_code!()
-    statuses = pmap(run_slurm_manifest_task, manifest["tasks"])
-
-    if MERGE_SUCCESSFUL_DBS
-        merge_successful_dbs(statuses, paths["successful_db_dir"], paths["merged_db"])
-    end
-    if WRITE_FAILURE_REPORT
-        write_failure_report(statuses, paths["failure_report"])
-    end
-
-    failures = count(status -> get(status, "state", "") != "success", statuses)
-    println("Completed $(length(statuses) - failures)/$(length(statuses)) family task(s) successfully.")
-    return statuses
-end
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    main()
-end
+results = vcat(light_results, heavy_results)

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -54,20 +54,71 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 @info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
 
 @everywhere begin
+    using Dates
+    using TOML
+
     include(joinpath(pwd(), "wiki_database_passes.jl"))
 
     const SLURM_DB_DIR = $MANIFEST_DB_DIR
+
+    timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
+
+    function output_database_files(task_manifest)
+        db_path = task_manifest["db_path"]
+        return isfile(db_path) ? [db_path] : String[]
+    end
+
+    function write_task_status(task_manifest; state, started_at, finished_at=nothing, exception_text=nothing)
+        status = Dict{String,Any}(
+            "task_id" => task_manifest["id"],
+            "family" => task_manifest["family"],
+            "worker_id" => myid(),
+            "started_at" => started_at,
+            "state" => state,
+            "db_path" => task_manifest["db_path"],
+            "db_filename" => task_manifest["db_filename"],
+            "output_database_files" => output_database_files(task_manifest),
+        )
+
+        if !isnothing(finished_at)
+            status["finished_at"] = finished_at
+        end
+
+        if !isnothing(exception_text)
+            status["exception_text"] = exception_text
+        end
+
+        status_path = task_manifest["status_path"]
+        mkpath(dirname(status_path))
+        open(status_path, "w") do io
+            TOML.print(io, status)
+        end
+    end
 
     function run_task(task_manifest)
         task_name = Symbol(task_manifest["family"])
         task = getproperty(CodeMetadata, task_name)
         @info "Running task: $task_name on $(myid())"
-        run_evaluations(
-            CodeMetadata.code_metadata;
-            include=[task],
-            db_path=SLURM_DB_DIR,
-            db_filename=task_manifest["db_filename"],
-        )
+        started_at = timestamp_utc()
+        write_task_status(task_manifest; state="running", started_at=started_at)
+        try
+            run_evaluations(
+                CodeMetadata.code_metadata;
+                include=[task],
+                db_path=SLURM_DB_DIR,
+                db_filename=task_manifest["db_filename"],
+            )
+            write_task_status(task_manifest; state="succeeded", started_at=started_at, finished_at=timestamp_utc())
+        catch err
+            write_task_status(
+                task_manifest;
+                state="failed",
+                started_at=started_at,
+                finished_at=timestamp_utc(),
+                exception_text=sprint(showerror, err),
+            )
+            rethrow()
+        end
         return "Result for $(task_name)"
     end
 end

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -63,7 +63,9 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
     const SLURM_DB_DIR = $MANIFEST_DB_DIR
 
-    timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
+    const SLURM_TIMESTAMP_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
+
+    timestamp_utc(t=Dates.now(Dates.UTC)) = Dates.format(t, SLURM_TIMESTAMP_FORMAT) * "Z"
 
     function output_database_files(task_manifest)
         db_path = task_manifest["db_path"]

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -55,6 +55,8 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
 @everywhere begin
     using Dates
+    using Logging
+    using TerminalLoggers
     using TOML
 
     include(joinpath(pwd(), "wiki_database_passes.jl"))
@@ -95,7 +97,36 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
         end
     end
 
-    function run_task(task_manifest)
+    function with_task_log(f, task_manifest)
+        log_path = task_manifest["log_path"]
+        mkpath(dirname(log_path))
+
+        open(log_path, "w") do log_io
+            task_logger = TerminalLogger(log_io; right_justify=120)
+            redirect_stdout(log_io) do
+                redirect_stderr(log_io) do
+                    with_logger(task_logger) do
+                        try
+                            result = f()
+                            flush(log_io)
+                            return result
+                        catch err
+                            println(log_io)
+                            println(log_io, "Task failed with exception:")
+                            showerror(log_io, err, catch_backtrace())
+                            println(log_io)
+                            flush(log_io)
+                            rethrow()
+                        finally
+                            flush(log_io)
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    function run_task_body(task_manifest)
         task_name = Symbol(task_manifest["family"])
         task = getproperty(CodeMetadata, task_name)
         @info "Running task: $task_name on $(myid())"
@@ -120,6 +151,12 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             rethrow()
         end
         return "Result for $(task_name)"
+    end
+
+    function run_task(task_manifest)
+        return with_task_log(task_manifest) do
+            run_task_body(task_manifest)
+        end
     end
 end
 

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -16,6 +16,8 @@ Pkg.activate(pwd())
 include(joinpath(pwd(), "script/slurm/slurm_manifest_generator.jl"))
 
 using .SlurmManifestGenerator: write_slurm_manifest
+using Dates
+using TOML
 
 const LIGHT_TASKS = [
     :Gottesman,
@@ -45,6 +47,95 @@ end
 const LIGHT_MANIFEST_TASKS = manifest_tasks(manifest, LIGHT_TASKS)
 const HEAVY_MANIFEST_TASKS = manifest_tasks(manifest, HEAVY_TASKS)
 const MANIFEST_DB_DIR = manifest["db_dir"]
+
+const RUN_SUMMARY_TIMESTAMP_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
+
+run_summary_timestamp_utc(t=Dates.now(Dates.UTC)) = Dates.format(t, RUN_SUMMARY_TIMESTAMP_FORMAT) * "Z"
+
+function task_status(task_manifest)
+    status_path = task_manifest["status_path"]
+    return isfile(status_path) ? TOML.parsefile(status_path) : nothing
+end
+
+function report_task_entry(task_manifest, status)
+    entry = Dict{String,Any}(
+        "task_id" => task_manifest["id"],
+        "family" => task_manifest["family"],
+        "log_path" => task_manifest["log_path"],
+        "db_path" => task_manifest["db_path"],
+        "status_path" => task_manifest["status_path"],
+    )
+
+    if isnothing(status)
+        entry["state"] = "missing"
+        return entry
+    end
+
+    for key in (
+        "state",
+        "worker_id",
+        "started_at",
+        "finished_at",
+        "exception_text",
+        "output_database_files",
+        "db_filename",
+    )
+        haskey(status, key) && (entry[key] = status[key])
+    end
+
+    return entry
+end
+
+function build_run_summary(manifest)
+    succeeded_tasks = Dict{String,Any}[]
+    failed_tasks = Dict{String,Any}[]
+    incomplete_tasks = Dict{String,Any}[]
+    missing_tasks = Dict{String,Any}[]
+
+    for task_manifest in manifest["tasks"]
+        status = task_status(task_manifest)
+        entry = report_task_entry(task_manifest, status)
+
+        if isnothing(status)
+            push!(missing_tasks, entry)
+        elseif get(status, "state", "") == "succeeded"
+            push!(succeeded_tasks, entry)
+        elseif get(status, "state", "") == "failed"
+            push!(failed_tasks, entry)
+        else
+            push!(incomplete_tasks, entry)
+        end
+    end
+
+    return Dict{String,Any}(
+        "run_id" => manifest["run_id"],
+        "generated_at" => run_summary_timestamp_utc(),
+        "manifest_path" => manifest["manifest_path"],
+        "total_tasks" => length(manifest["tasks"]),
+        "succeeded_count" => length(succeeded_tasks),
+        "failed_count" => length(failed_tasks),
+        "incomplete_count" => length(incomplete_tasks),
+        "missing_count" => length(missing_tasks),
+        "succeeded_tasks" => succeeded_tasks,
+        "failed_tasks" => failed_tasks,
+        "incomplete_tasks" => incomplete_tasks,
+        "missing_tasks" => missing_tasks,
+    )
+end
+
+function write_run_summary(manifest)
+    summary = build_run_summary(manifest)
+    summary_path = manifest["summary_path"]
+    mkpath(dirname(summary_path))
+    open(summary_path, "w") do io
+        TOML.print(io, summary)
+    end
+    return summary
+end
+
+function unsuccessful_task_count(summary)
+    return summary["failed_count"] + summary["incomplete_count"] + summary["missing_count"]
+end
 
 using Distributed
 using SlurmClusterManager
@@ -156,16 +247,52 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     end
 
     function run_task(task_manifest)
-        return with_task_log(task_manifest) do
-            run_task_body(task_manifest)
+        try
+            return with_task_log(task_manifest) do
+                result = run_task_body(task_manifest)
+                return Dict(
+                    "task_id" => task_manifest["id"],
+                    "family" => task_manifest["family"],
+                    "state" => "succeeded",
+                    "result" => result,
+                )
+            end
+        catch err
+            return Dict(
+                "task_id" => task_manifest["id"],
+                "family" => task_manifest["family"],
+                "state" => "failed",
+                "exception_text" => sprint(showerror, err),
+            )
         end
     end
 end
 
-light_results = pmap(run_task, LIGHT_MANIFEST_TASKS)
-
 const HEAVY_WORKER_COUNT = 1
-heavy_pool = WorkerPool(workers()[1:min(HEAVY_WORKER_COUNT, nworkers())])
-heavy_results = pmap(run_task, heavy_pool, HEAVY_MANIFEST_TASKS)
 
-results = vcat(light_results, heavy_results)
+function run_manifest_tasks()
+    results = Any[]
+    try
+        append!(results, pmap(run_task, LIGHT_MANIFEST_TASKS))
+
+        heavy_pool = WorkerPool(workers()[1:min(HEAVY_WORKER_COUNT, nworkers())])
+        append!(results, pmap(run_task, heavy_pool, HEAVY_MANIFEST_TASKS))
+    catch err
+        return results, err
+    end
+    return results, nothing
+end
+
+results, phase_error = run_manifest_tasks()
+
+summary = write_run_summary(manifest)
+@info "Wrote Slurm run summary" summary_path=manifest["summary_path"] succeeded=summary["succeeded_count"] failed=summary["failed_count"] incomplete=summary["incomplete_count"] missing=summary["missing_count"]
+
+if !isnothing(phase_error)
+    throw(phase_error)
+end
+
+unsuccessful = unsuccessful_task_count(summary)
+if unsuccessful > 0
+    error("Slurm run completed with $(unsuccessful) unsuccessful task(s); see $(manifest["summary_path"])")
+end

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -38,6 +38,29 @@ const HEAVY_TASKS = [
     :Triangular666,
 ]
 
+# Slurm evaluation model
+#
+# The manifest below expands each selected code family into one task for every
+# decoder/setup combination present in CodeMetadata.code_metadata. In other
+# words, the distributed unit is:
+#
+#     code family/type + decoder + setup
+#
+# not just a family, and not each individual parameterized code instance inside
+# metadata[:family]. Each task gets its own database, log, and status file. When
+# the task runs, run_task_body passes the manifest decoder/setup fields back into
+# run_evaluations as filters, so the task evaluates all instances of that family
+# for exactly that decoder/setup pair.
+#
+# This is usually the right granularity for Slurm: it improves load balancing,
+# makes failures smaller and easier to retry, and keeps logs/status reports tied
+# to the failing decoder/setup pair instead of rerunning an entire family. The
+# cost is extra scheduling and Julia task overhead, plus possible repeated setup
+# work such as reusable decoder construction that would otherwise be shared when
+# several setups are evaluated in one family-level call. For very small families
+# the old family-level batching can be cheaper; for heavy or uneven workloads,
+# the finer split should normally finish sooner and produce more actionable
+# failure artifacts.
 manifest_task_descriptors = expand_slurm_tasks(CodeMetadata.code_metadata, vcat(LIGHT_TASKS, HEAVY_TASKS))
 manifest = write_slurm_manifest(manifest_task_descriptors)
 @info "Wrote Slurm manifest" manifest_path=manifest["manifest_path"] run_dir=manifest["run_dir"]
@@ -54,6 +77,30 @@ const MANIFEST_DB_DIR = manifest["db_dir"]
 const RUN_SUMMARY_TIMESTAMP_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 
 run_summary_timestamp_utc(t=Dates.now(Dates.UTC)) = Dates.format(t, RUN_SUMMARY_TIMESTAMP_FORMAT) * "Z"
+
+function parse_run_summary_timestamp(timestamp)
+    return Dates.DateTime(chopsuffix(string(timestamp), "Z"), RUN_SUMMARY_TIMESTAMP_FORMAT)
+end
+
+function maybe_parse_run_summary_timestamp(timestamp)
+    try
+        return parse_run_summary_timestamp(timestamp)
+    catch
+        return nothing
+    end
+end
+
+function duration_seconds(started_at, finished_at)
+    return Dates.value(parse_run_summary_timestamp(finished_at) - parse_run_summary_timestamp(started_at)) / 1000
+end
+
+function maybe_duration_seconds(started_at, finished_at)
+    try
+        return duration_seconds(started_at, finished_at)
+    catch
+        return nothing
+    end
+end
 
 function task_status(task_manifest)
     status_path = task_manifest["status_path"]
@@ -88,11 +135,105 @@ function report_task_entry(task_manifest, status)
         "db_filename",
         "decoder",
         "setup",
+        "duration_seconds",
     )
         haskey(status, key) && (entry[key] = status[key])
     end
 
+    if !haskey(entry, "duration_seconds") && haskey(entry, "started_at") && haskey(entry, "finished_at")
+        duration = maybe_duration_seconds(entry["started_at"], entry["finished_at"])
+        !isnothing(duration) && (entry["duration_seconds"] = duration)
+    end
+
     return entry
+end
+
+function timed_task_entries(entries)
+    return [
+        entry for entry in entries
+        if haskey(entry, "duration_seconds")
+    ]
+end
+
+function aggregate_duration!(aggregates, key, duration)
+    group = string(key)
+    aggregate = get!(aggregates, group) do
+        Dict{String,Any}(
+            "task_count" => 0,
+            "total_duration_seconds" => 0.0,
+            "max_duration_seconds" => 0.0,
+        )
+    end
+    aggregate["task_count"] += 1
+    aggregate["total_duration_seconds"] += duration
+    aggregate["max_duration_seconds"] = max(aggregate["max_duration_seconds"], duration)
+    return aggregate
+end
+
+function duration_groups(entries, source_key, output_key)
+    aggregates = Dict{String,Any}()
+
+    for entry in entries
+        haskey(entry, source_key) || continue
+        duration = Float64(entry["duration_seconds"])
+        aggregate_duration!(aggregates, entry[source_key], duration)
+    end
+
+    return [
+        merge(Dict{String,Any}(output_key => key), aggregate)
+        for (key, aggregate) in sort(collect(aggregates); by=first)
+    ]
+end
+
+function slowest_task_entries(entries; limit=10)
+    sorted_entries = sort(entries; by=entry -> Float64(entry["duration_seconds"]), rev=true)
+
+    return [
+        Dict{String,Any}(
+            key => entry[key]
+            for key in ("task_id", "family", "decoder", "setup", "state", "duration_seconds")
+            if haskey(entry, key)
+        )
+        for entry in sorted_entries[1:min(limit, length(sorted_entries))]
+    ]
+end
+
+function timing_summary(entries)
+    started_timestamps = [
+        parse_run_summary_timestamp(entry["started_at"])
+        for entry in entries
+        if haskey(entry, "started_at") && !isnothing(maybe_parse_run_summary_timestamp(entry["started_at"]))
+    ]
+    finished_timestamps = [
+        parse_run_summary_timestamp(entry["finished_at"])
+        for entry in entries
+        if haskey(entry, "finished_at") && !isnothing(maybe_parse_run_summary_timestamp(entry["finished_at"]))
+    ]
+    timed_entries = timed_task_entries(entries)
+
+    summary = Dict{String,Any}(
+        "total_task_duration_seconds" => sum(Float64(entry["duration_seconds"]) for entry in timed_entries; init=0.0),
+        "slowest_tasks" => slowest_task_entries(timed_entries),
+        "duration_by_family" => duration_groups(timed_entries, "family", "family"),
+        "duration_by_decoder" => duration_groups(timed_entries, "decoder", "decoder"),
+        "duration_by_setup" => duration_groups(timed_entries, "setup", "setup"),
+    )
+
+    if !isempty(started_timestamps)
+        run_started_at = minimum(started_timestamps)
+        summary["run_started_at"] = Dates.format(run_started_at, RUN_SUMMARY_TIMESTAMP_FORMAT) * "Z"
+    end
+
+    if !isempty(finished_timestamps)
+        run_finished_at = maximum(finished_timestamps)
+        summary["run_finished_at"] = Dates.format(run_finished_at, RUN_SUMMARY_TIMESTAMP_FORMAT) * "Z"
+    end
+
+    if haskey(summary, "run_started_at") && haskey(summary, "run_finished_at")
+        summary["run_wall_time_seconds"] = duration_seconds(summary["run_started_at"], summary["run_finished_at"])
+    end
+
+    return summary
 end
 
 function build_run_summary(manifest)
@@ -116,7 +257,8 @@ function build_run_summary(manifest)
         end
     end
 
-    return Dict{String,Any}(
+    all_tasks = vcat(succeeded_tasks, failed_tasks, incomplete_tasks, missing_tasks)
+    summary = Dict{String,Any}(
         "run_id" => manifest["run_id"],
         "generated_at" => run_summary_timestamp_utc(),
         "manifest_path" => manifest["manifest_path"],
@@ -130,6 +272,9 @@ function build_run_summary(manifest)
         "incomplete_tasks" => incomplete_tasks,
         "missing_tasks" => missing_tasks,
     )
+
+    merge!(summary, timing_summary(all_tasks))
+    return summary
 end
 
 function write_run_summary(manifest)
@@ -169,6 +314,14 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
     timestamp_utc(t=Dates.now(Dates.UTC)) = Dates.format(t, SLURM_TIMESTAMP_FORMAT) * "Z"
 
+    function slurm_timestamp(timestamp)
+        return Dates.DateTime(chopsuffix(string(timestamp), "Z"), SLURM_TIMESTAMP_FORMAT)
+    end
+
+    function slurm_duration_seconds(started_at, finished_at)
+        return Dates.value(slurm_timestamp(finished_at) - slurm_timestamp(started_at)) / 1000
+    end
+
     function output_database_files(task_manifest)
         db_path = task_manifest["db_path"]
         return isfile(db_path) ? [db_path] : String[]
@@ -192,6 +345,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
         if !isnothing(finished_at)
             status["finished_at"] = finished_at
+            status["duration_seconds"] = slurm_duration_seconds(started_at, finished_at)
         end
 
         if !isnothing(exception_text)

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -1,21 +1,37 @@
 #!/usr/bin/env julia
 
-# Minimal Slurm manifest-check entrypoint.
+# Run with a command like:
+# sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
 #
-# This script keeps the same light/heavy task split as the working prototype,
-# but only writes a run manifest. It does not start Slurm workers or run
-# benchmarks yet.
+# Edit the config block below for each run. Each task calls run_evaluations for
+# one code family and lets the existing project helpers create result files.
+
+const REPO_ROOT = abspath(joinpath(@__DIR__, "..", ".."))
+
+using Pkg
+Pkg.activate(REPO_ROOT)
+cd(REPO_ROOT)
+
+using Dates
+using Distributed
+using SlurmClusterManager
+using TOML
 
 include(joinpath(@__DIR__, "slurm_manifest_generator.jl"))
+include(joinpath(REPO_ROOT, "_0.helpers_and_metadata", "db_join_helper.jl"))
 
 using .SlurmManifestGenerator: ManifestConfig, build_manifest, write_manifest_file
+using .DBJoinHelper: join_results
+
+# ---------------------------------------------------------------------------
+# Runner config
+# ---------------------------------------------------------------------------
 
 const RUN_ROOT = "runs/slurm"
 const RUN_ID = "" # Empty means use a timestamp-based run id.
-const ERROR_CHUNK_SIZE = 5
 const ALLOW_OVERWRITE = false
 
-const LIGHT_TASKS = [
+const INCLUDE_FAMILIES = [
     :Gottesman,
     :Toric,
     :Shor9,
@@ -23,40 +39,234 @@ const LIGHT_TASKS = [
     :Perfect5,
     :Cleve8,
     :Surface,
-]
-
-const HEAVY_TASKS = [
     :GeneralizedBicycle,
     :TwoBlockGroupAlgebra,
     :Triangular488,
     :Triangular666,
 ]
 
-function main()
-    repo_root = abspath(joinpath(@__DIR__, ".."))
-    project = SlurmManifestGenerator.load_project_metadata(repo_root)
+const MERGE_SUCCESSFUL_DBS = true
+const WRITE_FAILURE_REPORT = true
 
+# ---------------------------------------------------------------------------
+# Runner helpers
+# ---------------------------------------------------------------------------
+
+timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
+resolve_run_root(path) = isabspath(path) ? path : joinpath(REPO_ROOT, path)
+
+function write_toml_file(path, data)
+    mkpath(dirname(path))
+    open(path, "w") do io
+        TOML.print(io, data)
+    end
+    return path
+end
+
+function build_run_manifest()
+    project = SlurmManifestGenerator.load_project_metadata(REPO_ROOT)
     config = ManifestConfig(
-        run_root=RUN_ROOT,
+        run_root=resolve_run_root(RUN_ROOT),
         run_id=isempty(RUN_ID) ? nothing : RUN_ID,
-        include_families=vcat(LIGHT_TASKS, HEAVY_TASKS),
-        heavy_families=copy(HEAVY_TASKS),
-        error_chunk_size=ERROR_CHUNK_SIZE,
+        include_families=copy(INCLUDE_FAMILIES),
         allow_overwrite=ALLOW_OVERWRITE,
     )
 
     manifest = build_manifest(
         project.code_metadata,
         config;
-        repo_root,
+        repo_root=REPO_ROOT,
         family_name_fn=project.family_name_fn,
-        object_name_fn=project.object_name_fn,
     )
     manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
-
     println("Wrote Slurm run manifest: $manifest_path")
-    println("Planned tasks: $(length(manifest["tasks"]))")
-    return manifest_path
+    println("Planned family tasks: $(length(manifest["tasks"]))")
+    return manifest
+end
+
+function load_worker_code!()
+    @everywhere begin
+        using Dates
+        using TOML
+
+        cd($REPO_ROOT)
+        include(joinpath($REPO_ROOT, "wiki_database_passes.jl"))
+
+        function slurm_timestamp_utc(t=now(UTC))
+            return Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
+        end
+
+        function slurm_sqlite_files(dir)
+            isdir(dir) || return String[]
+            files = filter(path -> isfile(path) && endswith(lowercase(path), ".sqlite"), readdir(dir; join=true))
+            return sort(files)
+        end
+
+        function slurm_write_toml_file(path, data)
+            mkpath(dirname(path))
+            open(path, "w") do io
+                TOML.print(io, data)
+            end
+            return path
+        end
+
+        function slurm_family_from_task(task)
+            for family in keys(CodeMetadata.code_metadata)
+                string(Helpers.typenameof(family)) == task["family"] && return family
+            end
+            error("unknown code family in manifest task: $(task["family"])")
+        end
+
+        function slurm_task_summary(task)
+            return Dict{String,Any}(
+                "id" => task["id"],
+                "task_index" => task["task_index"],
+                "family" => task["family"],
+                "family_symbol" => task["family_symbol"],
+            )
+        end
+
+        function run_slurm_manifest_task(task)
+            artifacts = task["artifacts"]
+            db_dir = artifacts["db_dir"]
+            log_path = artifacts["log"]
+            status_path = artifacts["status"]
+            started_time = time()
+
+            status = Dict{String,Any}(
+                "id" => task["id"],
+                "state" => "running",
+                "worker" => myid(),
+                "started_at" => slurm_timestamp_utc(),
+                "task" => slurm_task_summary(task),
+                "artifacts" => artifacts,
+                "sqlite_files" => String[],
+            )
+
+            try
+                family = slurm_family_from_task(task)
+                mkpath(db_dir)
+                mkpath(dirname(log_path))
+
+                open(log_path, "w") do log_io
+                    redirect_stdout(log_io) do
+                        redirect_stderr(log_io) do
+                            println("Starting task $(task["id"]) for $(task["family"]) on worker $(myid()) at $(status["started_at"])")
+                            run_evaluations(
+                                CodeMetadata.code_metadata;
+                                include=[family],
+                                db_path=db_dir,
+                                worker_db=true,
+                            )
+                            println("Finished task $(task["id"]) at $(slurm_timestamp_utc())")
+                        end
+                    end
+                end
+                status["state"] = "success"
+            catch err
+                error_text = sprint(showerror, err, catch_backtrace())
+                status["state"] = "failed"
+                status["exception"] = error_text
+
+                try
+                    mkpath(dirname(log_path))
+                    open(log_path, "a") do log_io
+                        println(log_io)
+                        println(log_io, "Task $(task["id"]) failed at $(slurm_timestamp_utc())")
+                        println(log_io, error_text)
+                    end
+                catch log_err
+                    status["log_write_exception"] = sprint(showerror, log_err, catch_backtrace())
+                end
+            end
+
+            status["sqlite_files"] = slurm_sqlite_files(db_dir)
+            status["finished_at"] = slurm_timestamp_utc()
+            status["elapsed_seconds"] = time() - started_time
+            slurm_write_toml_file(status_path, status)
+            return status
+        end
+    end
+    return nothing
+end
+
+function stage_successful_dbs(statuses, stage_dir)
+    if isdir(stage_dir)
+        rm(stage_dir; recursive=true)
+    end
+    mkpath(stage_dir)
+
+    staged = String[]
+    for status in statuses
+        get(status, "state", "") == "success" || continue
+        for source in get(status, "sqlite_files", String[])
+            destination = joinpath(stage_dir, "$(status["id"])__$(basename(source))")
+            try
+                symlink(source, destination)
+            catch
+                cp(source, destination; force=true)
+            end
+            push!(staged, destination)
+        end
+    end
+    return staged
+end
+
+function merge_successful_dbs(statuses, successful_db_dir, output_path)
+    staged = stage_successful_dbs(statuses, successful_db_dir)
+    if isempty(staged)
+        println("No successful task databases to merge.")
+        return nothing
+    end
+
+    merged_path = join_results(successful_db_dir; output_path=output_path)
+    println("Merged $(length(staged)) successful task database(s) into $merged_path")
+    return merged_path
+end
+
+function write_failure_report(statuses, path)
+    failures = [status for status in statuses if get(status, "state", "") != "success"]
+    report = Dict{String,Any}(
+        "generated_at" => timestamp_utc(),
+        "failed_count" => length(failures),
+        "failures" => [
+            Dict{String,Any}(
+                "id" => status["id"],
+                "state" => status["state"],
+                "worker" => get(status, "worker", ""),
+                "task" => status["task"],
+                "artifacts" => status["artifacts"],
+                "sqlite_files" => get(status, "sqlite_files", String[]),
+                "exception" => get(status, "exception", ""),
+            )
+            for status in failures
+        ],
+    )
+    write_toml_file(path, report)
+    println("Wrote failure report: $path ($(length(failures)) failure(s))")
+    return path
+end
+
+function main()
+    manifest = build_run_manifest()
+    paths = manifest["artifacts"]
+
+    addprocs(SlurmManager(), exeflags="--project=$(REPO_ROOT)")
+    @info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
+
+    load_worker_code!()
+    statuses = pmap(run_slurm_manifest_task, manifest["tasks"])
+
+    if MERGE_SUCCESSFUL_DBS
+        merge_successful_dbs(statuses, paths["successful_db_dir"], paths["merged_db"])
+    end
+    if WRITE_FAILURE_REPORT
+        write_failure_report(statuses, paths["failure_report"])
+    end
+
+    failures = count(status -> get(status, "state", "") != "success", statuses)
+    println("Completed $(length(statuses) - failures)/$(length(statuses)) family task(s) successfully.")
+    return statuses
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -67,7 +67,6 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             include=[task],
             db_path=SLURM_DB_DIR,
             db_filename=task_manifest["db_filename"],
-            worker_db=true,
         )
         return "Result for $(task_name)"
     end

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -1,0 +1,64 @@
+#!/usr/bin/env julia
+
+# Minimal Slurm manifest-check entrypoint.
+#
+# This script keeps the same light/heavy task split as the working prototype,
+# but only writes a run manifest. It does not start Slurm workers or run
+# benchmarks yet.
+
+include(joinpath(@__DIR__, "slurm_manifest_generator.jl"))
+
+using .SlurmManifestGenerator: ManifestConfig, build_manifest, write_manifest_file
+
+const RUN_ROOT = "runs/slurm"
+const RUN_ID = "" # Empty means use a timestamp-based run id.
+const ERROR_CHUNK_SIZE = 5
+const ALLOW_OVERWRITE = false
+
+const LIGHT_TASKS = [
+    :Gottesman,
+    :Toric,
+    :Shor9,
+    :Steane7,
+    :Perfect5,
+    :Cleve8,
+    :Surface,
+]
+
+const HEAVY_TASKS = [
+    :GeneralizedBicycle,
+    :TwoBlockGroupAlgebra,
+    :Triangular488,
+    :Triangular666,
+]
+
+function main()
+    repo_root = abspath(joinpath(@__DIR__, ".."))
+    project = SlurmManifestGenerator.load_project_metadata(repo_root)
+
+    config = ManifestConfig(
+        run_root=RUN_ROOT,
+        run_id=isempty(RUN_ID) ? nothing : RUN_ID,
+        include_families=vcat(LIGHT_TASKS, HEAVY_TASKS),
+        heavy_families=copy(HEAVY_TASKS),
+        error_chunk_size=ERROR_CHUNK_SIZE,
+        allow_overwrite=ALLOW_OVERWRITE,
+    )
+
+    manifest = build_manifest(
+        project.code_metadata,
+        config;
+        repo_root,
+        family_name_fn=project.family_name_fn,
+        object_name_fn=project.object_name_fn,
+    )
+    manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
+
+    println("Wrote Slurm run manifest: $manifest_path")
+    println("Planned tasks: $(length(manifest["tasks"]))")
+    return manifest_path
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -6,7 +6,28 @@
 # Edit the config block below for each run. Each task calls run_evaluations for
 # one code family and lets the existing project helpers create result files.
 
-const REPO_ROOT = abspath(joinpath(@__DIR__, "..", ".."))
+function find_repo_root()
+    candidates = String[]
+    for env_key in ("QECCBENCHWIKI_REPO_ROOT", "SLURM_SUBMIT_DIR")
+        if haskey(ENV, env_key) && !isempty(ENV[env_key])
+            push!(candidates, ENV[env_key])
+        end
+    end
+    push!(candidates, pwd())
+    push!(candidates, joinpath(@__DIR__, "..", ".."))
+
+    for candidate in candidates
+        root = abspath(candidate)
+        if isfile(joinpath(root, "Project.toml")) && isfile(joinpath(root, "wiki_database_passes.jl"))
+            return root
+        end
+    end
+
+    error("Could not locate qECCBenchWiki repo root. Submit from the repo root, set --chdir to the repo root, or set QECCBENCHWIKI_REPO_ROOT.")
+end
+
+const REPO_ROOT = find_repo_root()
+const SLURM_SCRIPT_DIR = joinpath(REPO_ROOT, "script", "slurm")
 
 using Pkg
 Pkg.activate(REPO_ROOT)
@@ -17,7 +38,7 @@ using Distributed
 using SlurmClusterManager
 using TOML
 
-include(joinpath(@__DIR__, "slurm_manifest_generator.jl"))
+include(joinpath(SLURM_SCRIPT_DIR, "slurm_manifest_generator.jl"))
 include(joinpath(REPO_ROOT, "_0.helpers_and_metadata", "db_join_helper.jl"))
 
 using .SlurmManifestGenerator: ManifestConfig, build_manifest, write_manifest_file

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -6,27 +6,7 @@
 # Edit the config block below for each run. Each task calls run_evaluations for
 # one code family and lets the existing project helpers create result files.
 
-function find_repo_root()
-    candidates = String[]
-    for env_key in ("QECCBENCHWIKI_REPO_ROOT", "SLURM_SUBMIT_DIR")
-        if haskey(ENV, env_key) && !isempty(ENV[env_key])
-            push!(candidates, ENV[env_key])
-        end
-    end
-    push!(candidates, pwd())
-    push!(candidates, joinpath(@__DIR__, "..", ".."))
-
-    for candidate in candidates
-        root = abspath(candidate)
-        if isfile(joinpath(root, "Project.toml")) && isfile(joinpath(root, "wiki_database_passes.jl"))
-            return root
-        end
-    end
-
-    error("Could not locate qECCBenchWiki repo root. Submit from the repo root, set --chdir to the repo root, or set QECCBENCHWIKI_REPO_ROOT.")
-end
-
-const REPO_ROOT = find_repo_root()
+const REPO_ROOT = pwd()
 const SLURM_SCRIPT_DIR = joinpath(REPO_ROOT, "script", "slurm")
 
 using Pkg
@@ -106,10 +86,10 @@ function build_run_manifest()
 end
 
 function load_worker_code!()
-    @everywhere begin
-        using Dates
-        using TOML
+    remotecall_eval(Main, workers(), :(using Dates))
+    remotecall_eval(Main, workers(), :(using TOML))
 
+    @everywhere begin
         cd($REPO_ROOT)
         include(joinpath($REPO_ROOT, "wiki_database_passes.jl"))
 

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -3,10 +3,10 @@
 # This is the working version of our script
 
 # Run with a command like:
-# sbatch -N 3 -n 9 -t 06:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
+# sbatch -N 3 -n 9 -t 06:00:00 --mem-per-cpu=10g script/slurm/slurm.jl
 # Should be run from repo root!
 
-# Do instatiate in julia REPL
+# Do instantiate in julia REPL
 #ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
 
 using Pkg
@@ -466,7 +466,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     end
 end
 
-const HEAVY_WORKER_COUNT = 5
+const HEAVY_WORKER_COUNT = 7
 
 function run_manifest_tasks()
     results = Any[]

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -7,13 +7,13 @@
 # Should be run from repo root!
 
 # Do instatiate in julia REPL
-# ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
+ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
 
 using Pkg
 
 Pkg.activate(pwd())
 
-include("script/slurm/slurm_manifest_generator.jl")
+include(joinpath(pwd(), "script/slurm/slurm_manifest_generator.jl"))
 
 using .SlurmManifestGenerator: write_slurm_manifest
 

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -13,23 +13,9 @@ using Pkg
 
 Pkg.activate(pwd())
 
-using Distributed
-using SlurmClusterManager
+include("script/slurm/slurm_manifest_generator.jl")
 
-addprocs(SlurmManager(), exeflags="--project=$(pwd())")
-
-@info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
-
-@everywhere begin
-    include(joinpath(pwd(), "wiki_database_passes.jl"))
-
-    function run_task(task_name::Symbol)
-        task = getproperty(CodeMetadata, task_name)
-        @info "Running task: $task_name on $(myid())"
-        run_evaluations(CodeMetadata.code_metadata; include=[task], db_path=joinpath(pwd(), "codes/slurm_task_06_24/"), worker_db=true)
-        return "Result for $(task_name)"
-    end
-end
+using .SlurmManifestGenerator: write_slurm_manifest
 
 const LIGHT_TASKS = [
     :Gottesman,
@@ -48,10 +34,49 @@ const HEAVY_TASKS = [
     :Triangular666,
 ]
 
-light_results = pmap(run_task, LIGHT_TASKS)
+manifest = write_slurm_manifest(vcat(LIGHT_TASKS, HEAVY_TASKS))
+@info "Wrote Slurm manifest" manifest_path=manifest["manifest_path"] run_dir=manifest["run_dir"]
+
+function manifest_tasks(manifest, task_names)
+    task_by_family = Dict(Symbol(task["family"]) => task for task in manifest["tasks"])
+    return [task_by_family[task_name] for task_name in task_names]
+end
+
+const LIGHT_MANIFEST_TASKS = manifest_tasks(manifest, LIGHT_TASKS)
+const HEAVY_MANIFEST_TASKS = manifest_tasks(manifest, HEAVY_TASKS)
+const MANIFEST_DB_DIR = manifest["db_dir"]
+
+using Distributed
+using SlurmClusterManager
+
+addprocs(SlurmManager(), exeflags="--project=$(pwd())")
+
+@info "nprocs=$(nprocs()) nworkers=$(nworkers()) workers=$(workers())"
+
+@everywhere begin
+    include(joinpath(pwd(), "wiki_database_passes.jl"))
+
+    const SLURM_DB_DIR = $MANIFEST_DB_DIR
+
+    function run_task(task_manifest)
+        task_name = Symbol(task_manifest["family"])
+        task = getproperty(CodeMetadata, task_name)
+        @info "Running task: $task_name on $(myid())"
+        run_evaluations(
+            CodeMetadata.code_metadata;
+            include=[task],
+            db_path=SLURM_DB_DIR,
+            db_filename=task_manifest["db_filename"],
+            worker_db=true,
+        )
+        return "Result for $(task_name)"
+    end
+end
+
+light_results = pmap(run_task, LIGHT_MANIFEST_TASKS)
 
 const HEAVY_WORKER_COUNT = 1
 heavy_pool = WorkerPool(workers()[1:min(HEAVY_WORKER_COUNT, nworkers())])
-heavy_results = pmap(run_task, heavy_pool, HEAVY_TASKS)
+heavy_results = pmap(run_task, heavy_pool, HEAVY_MANIFEST_TASKS)
 
 results = vcat(light_results, heavy_results)

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -3,11 +3,11 @@
 # This is the working version of our script
 
 # Run with a command like:
-# sbatch -N 4 -n 12 -t 01:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
+# sbatch -N 3 -n 9 -t 06:00:00 --mem-per-cpu=8g script/slurm/slurm.jl
 # Should be run from repo root!
 
 # Do instatiate in julia REPL
-ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
+#ENV["ECCBENCHWIKI_QUICKCHECK"]="true"
 
 using Pkg
 
@@ -38,30 +38,33 @@ const HEAVY_TASKS = [
     :Triangular666,
 ]
 
+const TASK_DETAIL_FIELDS = ("code_instance", "decoder", "setup")
+
 # Slurm evaluation model
 #
-# The manifest below expands each selected code family into one task for every
-# decoder/setup combination present in CodeMetadata.code_metadata. In other
-# words, the distributed unit is:
+# The manifest below expands light code families into one task for every
+# decoder/setup combination, and heavy code families into one task for every
+# code instance/decoder/setup combination present in CodeMetadata.code_metadata.
+# In other words, the distributed unit is:
 #
-#     code family/type + decoder + setup
+#     light: code family/type + decoder + setup
+#     heavy: code family/type + code instance + decoder + setup
 #
-# not just a family, and not each individual parameterized code instance inside
-# metadata[:family]. Each task gets its own database, log, and status file. When
-# the task runs, run_task_body passes the manifest decoder/setup fields back into
-# run_evaluations as filters, so the task evaluates all instances of that family
-# for exactly that decoder/setup pair.
+# Each task gets its own database, log, and status file. When the task runs,
+# run_task_body passes the manifest code_instance/decoder/setup fields back into
+# run_evaluations as filters, so the task evaluates exactly that requested slice.
 #
 # This is usually the right granularity for Slurm: it improves load balancing,
 # makes failures smaller and easier to retry, and keeps logs/status reports tied
-# to the failing decoder/setup pair instead of rerunning an entire family. The
-# cost is extra scheduling and Julia task overhead, plus possible repeated setup
-# work such as reusable decoder construction that would otherwise be shared when
-# several setups are evaluated in one family-level call. For very small families
-# the old family-level batching can be cheaper; for heavy or uneven workloads,
-# the finer split should normally finish sooner and produce more actionable
-# failure artifacts.
-manifest_task_descriptors = expand_slurm_tasks(CodeMetadata.code_metadata, vcat(LIGHT_TASKS, HEAVY_TASKS))
+# to the failing task slice instead of rerunning an entire family. The cost is
+# extra scheduling and Julia task overhead. For very small families the old
+# decoder/setup batching can be cheaper; for heavy or uneven workloads, the
+# finer split should normally finish sooner and produce more actionable failure
+# artifacts.
+manifest_task_descriptors = vcat(
+    expand_slurm_tasks(CodeMetadata.code_metadata, LIGHT_TASKS),
+    expand_slurm_tasks(CodeMetadata.code_metadata, HEAVY_TASKS; split_code_instances=true),
+)
 manifest = write_slurm_manifest(manifest_task_descriptors)
 @info "Wrote Slurm manifest" manifest_path=manifest["manifest_path"] run_dir=manifest["run_dir"]
 
@@ -116,7 +119,7 @@ function report_task_entry(task_manifest, status)
         "status_path" => task_manifest["status_path"],
     )
 
-    for key in ("decoder", "setup")
+    for key in TASK_DETAIL_FIELDS
         haskey(task_manifest, key) && (entry[key] = task_manifest[key])
     end
 
@@ -133,6 +136,7 @@ function report_task_entry(task_manifest, status)
         "exception_text",
         "output_database_files",
         "db_filename",
+        "code_instance",
         "decoder",
         "setup",
         "duration_seconds",
@@ -191,7 +195,7 @@ function slowest_task_entries(entries; limit=10)
     return [
         Dict{String,Any}(
             key => entry[key]
-            for key in ("task_id", "family", "decoder", "setup", "state", "duration_seconds")
+            for key in ("task_id", "family", "code_instance", "decoder", "setup", "state", "duration_seconds")
             if haskey(entry, key)
         )
         for entry in sorted_entries[1:min(limit, length(sorted_entries))]
@@ -215,6 +219,7 @@ function timing_summary(entries)
         "total_task_duration_seconds" => sum(Float64(entry["duration_seconds"]) for entry in timed_entries; init=0.0),
         "slowest_tasks" => slowest_task_entries(timed_entries),
         "duration_by_family" => duration_groups(timed_entries, "family", "family"),
+        "duration_by_code_instance" => duration_groups(timed_entries, "code_instance", "code_instance"),
         "duration_by_decoder" => duration_groups(timed_entries, "decoder", "decoder"),
         "duration_by_setup" => duration_groups(timed_entries, "setup", "setup"),
     )
@@ -309,6 +314,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     end
 
     const SLURM_DB_DIR = $MANIFEST_DB_DIR
+    const SLURM_TASK_DETAIL_FIELDS = $TASK_DETAIL_FIELDS
 
     const SLURM_TIMESTAMP_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 
@@ -339,7 +345,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             "output_database_files" => output_database_files(task_manifest),
         )
 
-        for key in ("decoder", "setup")
+        for key in SLURM_TASK_DETAIL_FIELDS
             haskey(task_manifest, key) && (status[key] = task_manifest[key])
         end
 
@@ -390,7 +396,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
 
     function task_label(task_manifest)
         parts = String[string(task_manifest["family"])]
-        for key in ("decoder", "setup")
+        for key in SLURM_TASK_DETAIL_FIELDS
             haskey(task_manifest, key) && push!(parts, string(task_manifest[key]))
         end
         return join(parts, " / ")
@@ -399,6 +405,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     function run_task_body(task_manifest)
         task_name = Symbol(task_manifest["family"])
         task = getproperty(CodeMetadata, task_name)
+        code_instance_filter = haskey(task_manifest, "code_instance") ? [task_manifest["code_instance"]] : nothing
         decoder_filter = haskey(task_manifest, "decoder") ? [task_manifest["decoder"]] : nothing
         setup_filter = haskey(task_manifest, "setup") ? [task_manifest["setup"]] : nothing
         label = task_label(task_manifest)
@@ -409,6 +416,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             run_evaluations(
                 CodeMetadata.code_metadata;
                 include=[task],
+                code_instances=code_instance_filter,
                 decoders=decoder_filter,
                 setups=setup_filter,
                 db_path=SLURM_DB_DIR,
@@ -438,7 +446,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
                     "state" => "succeeded",
                     "result" => result,
                 )
-                for key in ("decoder", "setup")
+                for key in SLURM_TASK_DETAIL_FIELDS
                     haskey(task_manifest, key) && (task_result[key] = task_manifest[key])
                 end
                 return task_result
@@ -450,7 +458,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
                 "state" => "failed",
                 "exception_text" => sprint(showerror, err),
             )
-            for key in ("decoder", "setup")
+            for key in SLURM_TASK_DETAIL_FIELDS
                 haskey(task_manifest, key) && (task_result[key] = task_manifest[key])
             end
             return task_result
@@ -458,7 +466,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     end
 end
 
-const HEAVY_WORKER_COUNT = 1
+const HEAVY_WORKER_COUNT = 5
 
 function run_manifest_tasks()
     results = Any[]

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -15,9 +15,11 @@ Pkg.activate(pwd())
 
 include(joinpath(pwd(), "script/slurm/slurm_manifest_generator.jl"))
 
-using .SlurmManifestGenerator: write_slurm_manifest
+using .SlurmManifestGenerator: expand_slurm_tasks, write_slurm_manifest
 using Dates
 using TOML
+
+include(joinpath(pwd(), "wiki_database_passes.jl"))
 
 const LIGHT_TASKS = [
     :Gottesman,
@@ -36,12 +38,13 @@ const HEAVY_TASKS = [
     :Triangular666,
 ]
 
-manifest = write_slurm_manifest(vcat(LIGHT_TASKS, HEAVY_TASKS))
+manifest_task_descriptors = expand_slurm_tasks(CodeMetadata.code_metadata, vcat(LIGHT_TASKS, HEAVY_TASKS))
+manifest = write_slurm_manifest(manifest_task_descriptors)
 @info "Wrote Slurm manifest" manifest_path=manifest["manifest_path"] run_dir=manifest["run_dir"]
 
 function manifest_tasks(manifest, task_names)
-    task_by_family = Dict(Symbol(task["family"]) => task for task in manifest["tasks"])
-    return [task_by_family[task_name] for task_name in task_names]
+    requested = Set(Symbol.(task_names))
+    return [task for task in manifest["tasks"] if Symbol(task["family"]) in requested]
 end
 
 const LIGHT_MANIFEST_TASKS = manifest_tasks(manifest, LIGHT_TASKS)
@@ -156,7 +159,9 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
     using TerminalLoggers
     using TOML
 
-    include(joinpath(pwd(), "wiki_database_passes.jl"))
+    if myid() != 1
+        include(joinpath(pwd(), "wiki_database_passes.jl"))
+    end
 
     const SLURM_DB_DIR = $MANIFEST_DB_DIR
 
@@ -229,16 +234,29 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
         end
     end
 
+    function task_label(task_manifest)
+        parts = String[string(task_manifest["family"])]
+        for key in ("decoder", "setup")
+            haskey(task_manifest, key) && push!(parts, string(task_manifest[key]))
+        end
+        return join(parts, " / ")
+    end
+
     function run_task_body(task_manifest)
         task_name = Symbol(task_manifest["family"])
         task = getproperty(CodeMetadata, task_name)
-        @info "Running task: $task_name on $(myid())"
+        decoder_filter = haskey(task_manifest, "decoder") ? [task_manifest["decoder"]] : nothing
+        setup_filter = haskey(task_manifest, "setup") ? [task_manifest["setup"]] : nothing
+        label = task_label(task_manifest)
+        @info "Running task: $label on $(myid())"
         started_at = timestamp_utc()
         write_task_status(task_manifest; state="running", started_at=started_at)
         try
             run_evaluations(
                 CodeMetadata.code_metadata;
                 include=[task],
+                decoders=decoder_filter,
+                setups=setup_filter,
                 db_path=SLURM_DB_DIR,
                 db_filename=task_manifest["db_filename"],
             )
@@ -253,7 +271,7 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             )
             rethrow()
         end
-        return "Result for $(task_name)"
+        return "Result for $(label)"
     end
 
     function run_task(task_manifest)

--- a/script/slurm/slurm.jl
+++ b/script/slurm/slurm.jl
@@ -66,6 +66,10 @@ function report_task_entry(task_manifest, status)
         "status_path" => task_manifest["status_path"],
     )
 
+    for key in ("decoder", "setup")
+        haskey(task_manifest, key) && (entry[key] = task_manifest[key])
+    end
+
     if isnothing(status)
         entry["state"] = "missing"
         return entry
@@ -79,6 +83,8 @@ function report_task_entry(task_manifest, status)
         "exception_text",
         "output_database_files",
         "db_filename",
+        "decoder",
+        "setup",
     )
         haskey(status, key) && (entry[key] = status[key])
     end
@@ -175,6 +181,10 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
             "output_database_files" => output_database_files(task_manifest),
         )
 
+        for key in ("decoder", "setup")
+            haskey(task_manifest, key) && (status[key] = task_manifest[key])
+        end
+
         if !isnothing(finished_at)
             status["finished_at"] = finished_at
         end
@@ -250,20 +260,28 @@ addprocs(SlurmManager(), exeflags="--project=$(pwd())")
         try
             return with_task_log(task_manifest) do
                 result = run_task_body(task_manifest)
-                return Dict(
+                task_result = Dict(
                     "task_id" => task_manifest["id"],
                     "family" => task_manifest["family"],
                     "state" => "succeeded",
                     "result" => result,
                 )
+                for key in ("decoder", "setup")
+                    haskey(task_manifest, key) && (task_result[key] = task_manifest[key])
+                end
+                return task_result
             end
         catch err
-            return Dict(
+            task_result = Dict(
                 "task_id" => task_manifest["id"],
                 "family" => task_manifest["family"],
                 "state" => "failed",
                 "exception_text" => sprint(showerror, err),
             )
+            for key in ("decoder", "setup")
+                haskey(task_manifest, key) && (task_result[key] = task_manifest[key])
+            end
+            return task_result
         end
     end
 end

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -6,229 +6,65 @@ using Dates
 using TOML
 using UUIDs
 
-const SCHEMA_VERSION = "1"
-const RUN_ROOT = "runs/slurm"
-const RUN_ID = "" # Empty means use a timestamp-based run id.
-
-const INCLUDE_FAMILIES = [
-    :Gottesman,
-    :Toric,
-    :Shor9,
-    :Steane7,
-    :Perfect5,
-    :Cleve8,
-    :Surface,
-    :GeneralizedBicycle,
-    :TwoBlockGroupAlgebra,
-    :Triangular488,
-    :Triangular666,
-]
-
-const ALLOW_OVERWRITE = false
-
-Base.@kwdef struct ManifestConfig
-    run_root::String = RUN_ROOT
-    run_id::Union{Nothing,String} = isempty(RUN_ID) ? nothing : RUN_ID
-    include_families::Vector{Symbol} = copy(INCLUDE_FAMILIES)
-    allow_overwrite::Bool = ALLOW_OVERWRITE
-end
-
-export ManifestConfig,
-    artifact_paths,
-    build_manifest,
-    default_run_id,
-    main,
-    validate_manifest!,
-    write_manifest_file
+export build_slurm_manifest, default_run_id, write_slurm_manifest
 
 timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
 default_run_id(t=now(UTC)) = "slurm_" * Dates.format(t, dateformat"yyyymmdd_HHMMSS")
-resolved_run_id(config::ManifestConfig) = isnothing(config.run_id) || isempty(config.run_id) ? default_run_id() : config.run_id
-task_id() = "task_" * string(uuid4())
 
-function artifact_paths(run_root::AbstractString, run_id::AbstractString)
+function task_id(index, family)
+    return "task_$(lpad(string(index), 3, '0'))_$(family)"
+end
+
+db_filename(uuid) = "db_$(uuid).sqlite"
+
+function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_run_id())
     run_dir = joinpath(run_root, run_id)
-    return Dict{String,Any}(
-        "run_dir" => run_dir,
-        "manifest" => joinpath(run_dir, "manifest.toml"),
-        "db_dir" => joinpath(run_dir, "db"),
-        "successful_db_dir" => joinpath(run_dir, "db_successful"),
-        "log_dir" => joinpath(run_dir, "logs"),
-        "status_dir" => joinpath(run_dir, "status"),
-        "failure_report" => joinpath(run_dir, "failures.toml"),
-        "merged_db" => joinpath(run_dir, "merged_results.sqlite"),
-    )
-end
-
-default_family_name(family) = family isa Symbol ? string(family) : string(nameof(family))
-
-function family_lookup(code_metadata; family_name_fn=default_family_name)
-    lookup = Dict{Symbol,Any}()
-    for family in keys(code_metadata)
-        name = Symbol(family_name_fn(family))
-        haskey(lookup, name) && error("duplicate code family name in metadata: $name")
-        lookup[name] = family
-    end
-    return lookup
-end
-
-function task_artifacts(paths, id)
-    return Dict{String,Any}(
-        "db_dir" => joinpath(paths["db_dir"], id),
-        "log" => joinpath(paths["log_dir"], "$id.log"),
-        "status" => joinpath(paths["status_dir"], "$id.toml"),
-    )
-end
-
-function build_tasks(code_metadata, config::ManifestConfig, paths; family_name_fn=default_family_name)
-    lookup = family_lookup(code_metadata; family_name_fn)
-    missing_families = setdiff(config.include_families, collect(keys(lookup)))
-    isempty(missing_families) || error("unknown code families in include_families: $(join(string.(missing_families), ", "))")
+    manifest_path = joinpath(run_dir, "manifest.toml")
+    db_dir = joinpath(run_dir, "db")
+    log_dir = joinpath(run_dir, "logs")
 
     tasks = Dict{String,Any}[]
-    for (task_index, family_symbol) in enumerate(config.include_families)
-        family = lookup[family_symbol]
-        family_name = string(family_name_fn(family))
-        id = task_id()
-        push!(tasks, Dict{String,Any}(
+    for (index, family) in enumerate(task_names)
+        id = task_id(index, family)
+        uuid = string(uuid4())
+        filename = db_filename(uuid)
+        push!(tasks, Dict(
             "id" => id,
-            "task_index" => task_index,
-            "family" => family_name,
-            "family_symbol" => string(family_symbol),
-            "artifacts" => task_artifacts(paths, id),
+            "index" => index,
+            "family" => string(family),
+            "uuid" => uuid,
+            "db_filename" => filename,
+            "db_path" => joinpath(db_dir, filename),
+            "log_path" => joinpath(log_dir, "$(id).log"),
         ))
     end
 
-    validate_unique!(getindex.(tasks, "id"), "task id")
-    for artifact_name in ("db_dir", "log", "status")
-        validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
-    end
-    return tasks
-end
-
-function validate_unique!(values, label)
-    seen = Set{Any}()
-    duplicates = Any[]
-    for value in values
-        if value in seen
-            push!(duplicates, value)
-        end
-        push!(seen, value)
-    end
-    isempty(duplicates) || error("duplicate $label values: $(join(string.(unique(duplicates)), ", "))")
-    return values
-end
-
-function maybe_command_output(cmd::Cmd)
-    try
-        value = chomp(read(cmd, String))
-        return isempty(value) ? nothing : value
-    catch
-        return nothing
-    end
-end
-
-function git_metadata(repo_root=pwd())
-    metadata = Dict{String,Any}("available" => false)
-    commit = maybe_command_output(`git -C $repo_root rev-parse HEAD`)
-    isnothing(commit) && return metadata
-
-    branch = maybe_command_output(`git -C $repo_root branch --show-current`)
-    remote = maybe_command_output(`git -C $repo_root config --get remote.origin.url`)
-    dirty_status = maybe_command_output(`git -C $repo_root status --short`)
-
-    metadata["available"] = true
-    metadata["commit"] = commit
-    metadata["branch"] = isnothing(branch) ? "" : branch
-    metadata["remote"] = isnothing(remote) ? "" : remote
-    metadata["dirty"] = !isnothing(dirty_status)
-    return metadata
-end
-
-function build_manifest(code_metadata, config::ManifestConfig=ManifestConfig();
-    generated_at=timestamp_utc(),
-    repo_root=pwd(),
-    include_git=true,
-    family_name_fn=default_family_name,
-)
-    run_id = resolved_run_id(config)
-    paths = artifact_paths(config.run_root, run_id)
-    tasks = build_tasks(code_metadata, config, paths; family_name_fn)
-
-    manifest = Dict{String,Any}(
-        "schema_version" => SCHEMA_VERSION,
-        "generated_at" => generated_at,
-        "run" => Dict{String,Any}(
-            "id" => run_id,
-            "root" => config.run_root,
-        ),
-        "config" => Dict{String,Any}(
-            "include_families" => string.(config.include_families),
-            "allow_overwrite" => config.allow_overwrite,
-        ),
-        "artifacts" => paths,
-        "git" => include_git ? git_metadata(repo_root) : Dict{String,Any}("available" => false),
+    return Dict(
+        "run_id" => run_id,
+        "run_dir" => run_dir,
+        "generated_at" => timestamp_utc(),
+        "manifest_path" => manifest_path,
+        "db_dir" => db_dir,
+        "log_dir" => log_dir,
         "tasks" => tasks,
     )
-    validate_manifest!(manifest)
-    return manifest
 end
 
-function validate_manifest!(manifest)
-    tasks = manifest["tasks"]
-    validate_unique!(getindex.(tasks, "id"), "task id")
-    for artifact_name in ("db_dir", "log", "status")
-        validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
-    end
-    return manifest
-end
+function write_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_run_id())
+    manifest = build_slurm_manifest(task_names; run_root, run_id)
 
-function write_manifest_file(manifest; allow_overwrite=false)
-    paths = manifest["artifacts"]
-    run_dir = paths["run_dir"]
-    if isdir(run_dir) && !allow_overwrite
-        error("run directory already exists: $run_dir; set ALLOW_OVERWRITE = true to write into it")
+    if ispath(manifest["run_dir"])
+        error("Slurm run directory already exists: $(manifest["run_dir"])")
     end
 
-    mkpath(run_dir)
-    mkpath(paths["db_dir"])
-    mkpath(paths["log_dir"])
-    mkpath(paths["status_dir"])
+    mkpath(manifest["db_dir"])
+    mkpath(manifest["log_dir"])
 
-    manifest_path = paths["manifest"]
-    open(manifest_path, "w") do io
+    open(manifest["manifest_path"], "w") do io
         TOML.print(io, manifest)
     end
-    return manifest_path
+
+    return manifest
 end
 
-function load_project_metadata(repo_root=pwd())
-    include(joinpath(repo_root, "_0.helpers_and_metadata", "helpers.jl"))
-    include(joinpath(repo_root, "_0.helpers_and_metadata", "code_metadata.jl"))
-    return (
-        code_metadata=CodeMetadata.code_metadata,
-        family_name_fn=Helpers.typenameof,
-    )
-end
-
-function main()
-    repo_root = abspath(joinpath(@__DIR__, "..", ".."))
-    project = load_project_metadata(repo_root)
-    config = ManifestConfig()
-    manifest = build_manifest(
-        project.code_metadata,
-        config;
-        repo_root,
-        family_name_fn=project.family_name_fn,
-    )
-    manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
-    println("Wrote Slurm run manifest: $manifest_path")
-    println("Planned tasks: $(length(manifest["tasks"]))")
-    return manifest_path
-end
-
-end # module
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    SlurmManifestGenerator.main()
 end

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -22,6 +22,7 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
     manifest_path = joinpath(run_dir, "manifest.toml")
     db_dir = joinpath(run_dir, "db")
     log_dir = joinpath(run_dir, "logs")
+    status_dir = joinpath(run_dir, "status")
 
     tasks = Dict{String,Any}[]
     for (index, family) in enumerate(task_names)
@@ -36,6 +37,7 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
             "db_filename" => filename,
             "db_path" => joinpath(db_dir, filename),
             "log_path" => joinpath(log_dir, "$(id).log"),
+            "status_path" => joinpath(status_dir, "$(id).toml"),
         ))
     end
 
@@ -46,6 +48,7 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
         "manifest_path" => manifest_path,
         "db_dir" => db_dir,
         "log_dir" => log_dir,
+        "status_dir" => status_dir,
         "tasks" => tasks,
     )
 end
@@ -59,6 +62,7 @@ function write_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
 
     mkpath(manifest["db_dir"])
     mkpath(manifest["log_dir"])
+    mkpath(manifest["status_dir"])
 
     open(manifest["manifest_path"], "w") do io
         TOML.print(io, manifest)

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -20,6 +20,7 @@ db_filename(uuid) = "db_$(uuid).sqlite"
 function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_run_id())
     run_dir = joinpath(run_root, run_id)
     manifest_path = joinpath(run_dir, "manifest.toml")
+    summary_path = joinpath(run_dir, "summary.toml")
     db_dir = joinpath(run_dir, "db")
     log_dir = joinpath(run_dir, "logs")
     status_dir = joinpath(run_dir, "status")
@@ -46,6 +47,7 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
         "run_dir" => run_dir,
         "generated_at" => timestamp_utc(),
         "manifest_path" => manifest_path,
+        "summary_path" => summary_path,
         "db_dir" => db_dir,
         "log_dir" => log_dir,
         "status_dir" => status_dir,

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -15,7 +15,54 @@ function task_id(index, family)
     return "task_$(lpad(string(index), 3, '0'))_$(family)"
 end
 
+function task_id(index, family, decoder, setup)
+    parts = String[string(family)]
+    !isnothing(decoder) && push!(parts, string(decoder))
+    !isnothing(setup) && push!(parts, string(setup))
+    suffix = join(sanitize_task_id_part.(parts), "_")
+    return "task_$(lpad(string(index), 3, '0'))_$(suffix)"
+end
+
+function sanitize_task_id_part(value)
+    sanitized = replace(string(value), r"[^A-Za-z0-9]+" => "_")
+    sanitized = replace(sanitized, r"^_+|_+$" => "")
+    return isempty(sanitized) ? "task" : sanitized
+end
+
 db_filename(uuid) = "db_$(uuid).sqlite"
+
+function get_task_field(task, field::Symbol, default=nothing)
+    haskey(task, field) && return task[field]
+    string_field = string(field)
+    haskey(task, string_field) && return task[string_field]
+    return default
+end
+
+function normalized_task(task)
+    return Dict{String,Any}(
+        "family" => string(task),
+    )
+end
+
+function normalized_task(task::AbstractDict)
+    family = get_task_field(task, :family)
+    isnothing(family) && error("Slurm manifest task descriptor is missing required field: family")
+
+    normalized = Dict{String,Any}(
+        "family" => string(family),
+    )
+
+    decoder = get_task_field(task, :decoder)
+    setup = get_task_field(task, :setup)
+    !isnothing(decoder) && (normalized["decoder"] = string(decoder))
+    !isnothing(setup) && (normalized["setup"] = string(setup))
+
+    return normalized
+end
+
+function normalized_task(task::NamedTuple)
+    return normalized_task(Dict{Symbol,Any}(pairs(task)))
+end
 
 function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_run_id())
     run_dir = joinpath(run_root, run_id)
@@ -26,11 +73,15 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
     status_dir = joinpath(run_dir, "status")
 
     tasks = Dict{String,Any}[]
-    for (index, family) in enumerate(task_names)
-        id = task_id(index, family)
+    for (index, task_name) in enumerate(task_names)
+        task = normalized_task(task_name)
+        family = task["family"]
+        decoder = get(task, "decoder", nothing)
+        setup = get(task, "setup", nothing)
+        id = isnothing(decoder) && isnothing(setup) ? task_id(index, family) : task_id(index, family, decoder, setup)
         uuid = string(uuid4())
         filename = db_filename(uuid)
-        push!(tasks, Dict(
+        task_manifest = Dict(
             "id" => id,
             "index" => index,
             "family" => string(family),
@@ -39,7 +90,12 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
             "db_path" => joinpath(db_dir, filename),
             "log_path" => joinpath(log_dir, "$(id).log"),
             "status_path" => joinpath(status_dir, "$(id).toml"),
-        ))
+        )
+
+        haskey(task, "decoder") && (task_manifest["decoder"] = task["decoder"])
+        haskey(task, "setup") && (task_manifest["setup"] = task["setup"])
+
+        push!(tasks, task_manifest)
     end
 
     return Dict(

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -6,7 +6,7 @@ using Dates
 using TOML
 using UUIDs
 
-export build_slurm_manifest, default_run_id, write_slurm_manifest
+export build_slurm_manifest, default_run_id, expand_slurm_tasks, write_slurm_manifest
 
 timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
 default_run_id(t=now(UTC)) = "slurm_" * Dates.format(t, dateformat"yyyymmdd_HHMMSS")
@@ -30,6 +30,59 @@ function sanitize_task_id_part(value)
 end
 
 db_filename(uuid) = "db_$(uuid).sqlite"
+
+filter_items(filters::AbstractString) = (filters,)
+filter_items(filters::AbstractVector) = filters
+filter_items(filters::Tuple) = filters
+filter_items(filters) = (filters,)
+
+family_items(families::AbstractVector) = families
+family_items(families::Tuple) = families
+family_items(families) = (families,)
+
+function skip_redundant_prefix(value)
+    return chopprefix(chopprefix(string(value), "QuantumClifford.ECC."), "Main.")
+end
+
+function skip_redundant_suffix(value)
+    parts = split(string(value), "(")
+    fixed = [
+        chopsuffix(chopsuffix(part, "Decoder"), "ECCSetup")
+        for part in parts
+    ]
+    return join(fixed, "(")
+end
+
+function manifest_name(value)
+    if hasproperty(value, :f) && hasproperty(value, :kwargs)
+        f = manifest_name(getproperty(value, :f))
+        kwargs = getproperty(value, :kwargs)
+        return "$f($(join(["$key=$val" for (key, val) in pairs(kwargs)], ", ")))"
+    end
+
+    return skip_redundant_suffix(skip_redundant_prefix(value))
+end
+
+function matches_filter(entry, filter)
+    entry == filter && return true
+    return manifest_name(entry) == manifest_name(filter)
+end
+
+function filtered_entries(entries, filters)
+    isnothing(filters) && return entries
+    selected = filter_items(filters)
+    return [entry for entry in entries if any(filter -> matches_filter(entry, filter), selected)]
+end
+
+function family_name(family)
+    hasproperty(family, :code_name) && return string(getproperty(family, :code_name))
+
+    try
+        return string(nameof(family))
+    catch
+        return string(family)
+    end
+end
 
 function get_task_field(task, field::Symbol, default=nothing)
     haskey(task, field) && return task[field]
@@ -62,6 +115,41 @@ end
 
 function normalized_task(task::NamedTuple)
     return normalized_task(Dict{Symbol,Any}(pairs(task)))
+end
+
+function expand_slurm_tasks(code_metadata, families; decoders=nothing, setups=nothing)
+    requested = Symbol.(family_items(families))
+    requested_set = Set(requested)
+    expanded = Dict{String,Any}[]
+    metadata_by_family = Dict{Symbol,Any}()
+
+    for (codetype, metadata) in code_metadata
+        family = family_name(codetype)
+        family_symbol = Symbol(family)
+        family_symbol in requested_set || continue
+        metadata_by_family[family_symbol] = (family, metadata)
+    end
+
+    missing = setdiff(requested_set, Set(keys(metadata_by_family)))
+    !isempty(missing) && error("Slurm manifest task expansion requested unknown family/families: $(join(sort!(string.(collect(missing))), ", "))")
+
+    for family_symbol in requested
+        family, metadata = metadata_by_family[family_symbol]
+        family_decoders = filtered_entries(metadata[:decoders], decoders)
+        family_setups = filtered_entries(metadata[:setups], setups)
+
+        for decoder in family_decoders
+            for setup in family_setups
+                push!(expanded, Dict(
+                    "family" => family,
+                    "decoder" => manifest_name(decoder),
+                    "setup" => manifest_name(setup),
+                ))
+            end
+        end
+    end
+
+    return expanded
 end
 
 function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_run_id())

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -4,20 +4,13 @@ module SlurmManifestGenerator
 
 using Dates
 using TOML
-
-# ---------------------------------------------------------------------------
-# Configuration
-#
-# Edit these constants to change the default manifest generation plan.
-# This script only writes a manifest; it does not submit Slurm jobs or run
-# benchmarks.
-# ---------------------------------------------------------------------------
+using UUIDs
 
 const SCHEMA_VERSION = "1"
-const RUN_ROOT = "run/slurm"
+const RUN_ROOT = "runs/slurm"
 const RUN_ID = "" # Empty means use a timestamp-based run id.
 
-const LIGHT_FAMILIES = [
+const INCLUDE_FAMILIES = [
     :Gottesman,
     :Toric,
     :Shor9,
@@ -25,58 +18,33 @@ const LIGHT_FAMILIES = [
     :Perfect5,
     :Cleve8,
     :Surface,
-]
-
-const HEAVY_FAMILIES = [
     :GeneralizedBicycle,
     :TwoBlockGroupAlgebra,
     :Triangular488,
     :Triangular666,
 ]
 
-const INCLUDE_FAMILIES = vcat(LIGHT_FAMILIES, HEAVY_FAMILIES)
-const ERROR_CHUNK_SIZE = 5
 const ALLOW_OVERWRITE = false
 
 Base.@kwdef struct ManifestConfig
     run_root::String = RUN_ROOT
     run_id::Union{Nothing,String} = isempty(RUN_ID) ? nothing : RUN_ID
     include_families::Vector{Symbol} = copy(INCLUDE_FAMILIES)
-    heavy_families::Vector{Symbol} = copy(HEAVY_FAMILIES)
-    error_chunk_size::Int = ERROR_CHUNK_SIZE
     allow_overwrite::Bool = ALLOW_OVERWRITE
 end
 
 export ManifestConfig,
     artifact_paths,
     build_manifest,
-    chunk_ranges,
     default_run_id,
     main,
-    planned_nsamples,
     validate_manifest!,
     write_manifest_file
 
 timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
 default_run_id(t=now(UTC)) = "slurm_" * Dates.format(t, dateformat"yyyymmdd_HHMMSS")
 resolved_run_id(config::ManifestConfig) = isnothing(config.run_id) || isempty(config.run_id) ? default_run_id() : config.run_id
-
-"""
-Split a collection of items into contiguous chunks of a specified size, returning the index ranges for each chunk. 
-"""
-function chunk_ranges(nitems::Integer, chunk_size::Integer)
-    chunk_size > 0 || throw(ArgumentError("error_chunk_size must be positive; got $chunk_size"))
-    nitems >= 0 || throw(ArgumentError("nitems must be nonnegative; got $nitems"))
-
-    ranges = UnitRange{Int}[]
-    first_index = 1
-    while first_index <= nitems
-        last_index = min(first_index + chunk_size - 1, nitems)
-        push!(ranges, first_index:last_index)
-        first_index = last_index + 1
-    end
-    return ranges
-end
+task_id() = "task_" * string(uuid4())
 
 function artifact_paths(run_root::AbstractString, run_id::AbstractString)
     run_dir = joinpath(run_root, run_id)
@@ -84,6 +52,7 @@ function artifact_paths(run_root::AbstractString, run_id::AbstractString)
         "run_dir" => run_dir,
         "manifest" => joinpath(run_dir, "manifest.toml"),
         "db_dir" => joinpath(run_dir, "db"),
+        "successful_db_dir" => joinpath(run_dir, "db_successful"),
         "log_dir" => joinpath(run_dir, "logs"),
         "status_dir" => joinpath(run_dir, "status"),
         "failure_report" => joinpath(run_dir, "failures.toml"),
@@ -91,21 +60,7 @@ function artifact_paths(run_root::AbstractString, run_id::AbstractString)
     )
 end
 
-# Keep manifest sample planning aligned with the current benchmark pass without
-# loading the benchmark module and its runtime dependencies.
-planned_nsamples(error_rate::Real) = get(ENV, "ECCBENCHWIKI_QUICKCHECK", "") == "" ? Int(ceil(40 / error_rate)) : 10
-
 default_family_name(family) = family isa Symbol ? string(family) : string(nameof(family))
-default_object_name(x) = string(x)
-manifest_value(x) = string(x)
-
-function errrange_values(errrange)
-    errmin, errmax, steps = errrange
-    steps > 0 || throw(ArgumentError("errrange steps must be positive; got $steps"))
-    errmin > 0 || throw(ArgumentError("errrange minimum must be positive; got $errmin"))
-    errmax > 0 || throw(ArgumentError("errrange maximum must be positive; got $errmax"))
-    return collect(exp.(range(log(errmin), log(errmax), length=steps)))
-end
 
 function family_lookup(code_metadata; family_name_fn=default_family_name)
     lookup = Dict{Symbol,Any}()
@@ -117,80 +72,35 @@ function family_lookup(code_metadata; family_name_fn=default_family_name)
     return lookup
 end
 
-function tuple_display(args)
-    values = string.(collect(args))
-    isempty(values) && return "()"
-    suffix = length(values) == 1 ? "," : ""
-    return "(" * join(values, ", ") * suffix * ")"
-end
-
-function task_artifacts(paths, task_id)
+function task_artifacts(paths, id)
     return Dict{String,Any}(
-        "db" => joinpath(paths["db_dir"], "$task_id.sqlite"),
-        "log" => joinpath(paths["log_dir"], "$task_id.log"),
-        "status" => joinpath(paths["status_dir"], "$task_id.toml"),
-        "failure" => joinpath(paths["status_dir"], "$task_id.failure.toml"),
+        "db_dir" => joinpath(paths["db_dir"], id),
+        "log" => joinpath(paths["log_dir"], "$id.log"),
+        "status" => joinpath(paths["status_dir"], "$id.toml"),
     )
 end
 
-function build_tasks(code_metadata, config::ManifestConfig, paths;
-    family_name_fn=default_family_name,
-    object_name_fn=default_object_name,
-)
-    config.error_chunk_size > 0 || throw(ArgumentError("error_chunk_size must be positive; got $(config.error_chunk_size)"))
-
+function build_tasks(code_metadata, config::ManifestConfig, paths; family_name_fn=default_family_name)
     lookup = family_lookup(code_metadata; family_name_fn)
     missing_families = setdiff(config.include_families, collect(keys(lookup)))
     isempty(missing_families) || error("unknown code families in include_families: $(join(string.(missing_families), ", "))")
 
     tasks = Dict{String,Any}[]
-    task_index = 0
-    heavy = Set(config.heavy_families)
-
-    for family_symbol in config.include_families
+    for (task_index, family_symbol) in enumerate(config.include_families)
         family = lookup[family_symbol]
-        metadata = code_metadata[family]
-        family_name = string(family_symbol)
-        errrange = metadata[:errrange]
-        errors = errrange_values(errrange)
-        ranges = chunk_ranges(length(errors), config.error_chunk_size)
-        weight_class = family_symbol in heavy ? "heavy" : "light"
-
-        for (family_index, family_args) in enumerate(metadata[:family])
-            code_instance = family_name * tuple_display(family_args)
-            for (decoder_index, decoder) in enumerate(metadata[:decoders])
-                for (setup_index, setup) in enumerate(metadata[:setups])
-                    for (chunk_index, error_range) in enumerate(ranges)
-                        task_index += 1
-                        task_id = "task_" * lpad(string(task_index), 6, "0")
-                        chunk_errors = errors[error_range]
-                        push!(tasks, Dict{String,Any}(
-                            "id" => task_id,
-                            "task_index" => task_index,
-                            "weight_class" => weight_class,
-                            "family" => family_name,
-                            "family_index" => family_index,
-                            "family_args" => manifest_value.(collect(family_args)),
-                            "family_args_display" => tuple_display(family_args),
-                            "code_instance" => code_instance,
-                            "decoder_index" => decoder_index,
-                            "decoder" => string(object_name_fn(decoder)),
-                            "setup_index" => setup_index,
-                            "setup" => string(object_name_fn(setup)),
-                            "error_chunk_index" => chunk_index,
-                            "error_indices" => collect(error_range),
-                            "errors" => Float64.(chunk_errors),
-                            "planned_nsamples" => planned_nsamples.(chunk_errors),
-                            "artifacts" => task_artifacts(paths, task_id),
-                        ))
-                    end
-                end
-            end
-        end
+        family_name = string(family_name_fn(family))
+        id = task_id()
+        push!(tasks, Dict{String,Any}(
+            "id" => id,
+            "task_index" => task_index,
+            "family" => family_name,
+            "family_symbol" => string(family_symbol),
+            "artifacts" => task_artifacts(paths, id),
+        ))
     end
 
     validate_unique!(getindex.(tasks, "id"), "task id")
-    for artifact_name in ("db", "log", "status", "failure")
+    for artifact_name in ("db_dir", "log", "status")
         validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
     end
     return tasks
@@ -240,11 +150,10 @@ function build_manifest(code_metadata, config::ManifestConfig=ManifestConfig();
     repo_root=pwd(),
     include_git=true,
     family_name_fn=default_family_name,
-    object_name_fn=default_object_name,
 )
     run_id = resolved_run_id(config)
     paths = artifact_paths(config.run_root, run_id)
-    tasks = build_tasks(code_metadata, config, paths; family_name_fn, object_name_fn)
+    tasks = build_tasks(code_metadata, config, paths; family_name_fn)
 
     manifest = Dict{String,Any}(
         "schema_version" => SCHEMA_VERSION,
@@ -255,8 +164,6 @@ function build_manifest(code_metadata, config::ManifestConfig=ManifestConfig();
         ),
         "config" => Dict{String,Any}(
             "include_families" => string.(config.include_families),
-            "heavy_families" => string.(config.heavy_families),
-            "error_chunk_size" => config.error_chunk_size,
             "allow_overwrite" => config.allow_overwrite,
         ),
         "artifacts" => paths,
@@ -270,7 +177,7 @@ end
 function validate_manifest!(manifest)
     tasks = manifest["tasks"]
     validate_unique!(getindex.(tasks, "id"), "task id")
-    for artifact_name in ("db", "log", "status", "failure")
+    for artifact_name in ("db_dir", "log", "status")
         validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
     end
     return manifest
@@ -301,12 +208,11 @@ function load_project_metadata(repo_root=pwd())
     return (
         code_metadata=CodeMetadata.code_metadata,
         family_name_fn=Helpers.typenameof,
-        object_name_fn=Helpers.skipredundantfix,
     )
 end
 
 function main()
-    repo_root = abspath(joinpath(@__DIR__, ".."))
+    repo_root = abspath(joinpath(@__DIR__, "..", ".."))
     project = load_project_metadata(repo_root)
     config = ManifestConfig()
     manifest = build_manifest(
@@ -314,7 +220,6 @@ function main()
         config;
         repo_root,
         family_name_fn=project.family_name_fn,
-        object_name_fn=project.object_name_fn,
     )
     manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
     println("Wrote Slurm run manifest: $manifest_path")

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -11,6 +11,8 @@ export build_slurm_manifest, default_run_id, expand_slurm_tasks, write_slurm_man
 timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
 default_run_id(t=now(UTC)) = "slurm_" * Dates.format(t, dateformat"yyyymmdd_HHMMSS")
 
+const TASK_DETAIL_FIELDS = ("code_instance", "decoder", "setup")
+
 function task_id(index, family)
     return "task_$(lpad(string(index), 3, '0'))_$(family)"
 end
@@ -23,8 +25,30 @@ function task_id(index, family, decoder, setup)
     return "task_$(lpad(string(index), 3, '0'))_$(suffix)"
 end
 
+function task_id(index, family, code_instance, decoder, setup)
+    parts = String[string(family)]
+    !isnothing(code_instance) && push!(parts, string(code_instance))
+    !isnothing(decoder) && push!(parts, string(decoder))
+    !isnothing(setup) && push!(parts, string(setup))
+    suffix = join(sanitize_task_id_part.(parts), "_")
+    return "task_$(lpad(string(index), 3, '0'))_$(suffix)"
+end
+
 function sanitize_task_id_part(value)
-    sanitized = replace(string(value), r"[^A-Za-z0-9]+" => "_")
+    normalized = replace(
+        string(value),
+        "₀" => "0",
+        "₁" => "1",
+        "₂" => "2",
+        "₃" => "3",
+        "₄" => "4",
+        "₅" => "5",
+        "₆" => "6",
+        "₇" => "7",
+        "₈" => "8",
+        "₉" => "9",
+    )
+    sanitized = replace(normalized, r"[^A-Za-z0-9]+" => "_")
     sanitized = replace(sanitized, r"^_+|_+$" => "")
     return isempty(sanitized) ? "task" : sanitized
 end
@@ -84,6 +108,11 @@ function family_name(family)
     end
 end
 
+function instance_name(family, instance_args)
+    args = instance_args isa Tuple ? instance_args : (instance_args,)
+    return "$(family)($(join(string.(args), ", ")))"
+end
+
 function get_task_field(task, field::Symbol, default=nothing)
     haskey(task, field) && return task[field]
     string_field = string(field)
@@ -105,10 +134,10 @@ function normalized_task(task::AbstractDict)
         "family" => string(family),
     )
 
-    decoder = get_task_field(task, :decoder)
-    setup = get_task_field(task, :setup)
-    !isnothing(decoder) && (normalized["decoder"] = string(decoder))
-    !isnothing(setup) && (normalized["setup"] = string(setup))
+    for field in TASK_DETAIL_FIELDS
+        value = get_task_field(task, Symbol(field))
+        !isnothing(value) && (normalized[field] = string(value))
+    end
 
     return normalized
 end
@@ -117,7 +146,7 @@ function normalized_task(task::NamedTuple)
     return normalized_task(Dict{Symbol,Any}(pairs(task)))
 end
 
-function expand_slurm_tasks(code_metadata, families; decoders=nothing, setups=nothing)
+function expand_slurm_tasks(code_metadata, families; code_instances=nothing, decoders=nothing, setups=nothing, split_code_instances=false)
     requested = Symbol.(family_items(families))
     requested_set = Set(requested)
     expanded = Dict{String,Any}[]
@@ -135,16 +164,35 @@ function expand_slurm_tasks(code_metadata, families; decoders=nothing, setups=no
 
     for family_symbol in requested
         family, metadata = metadata_by_family[family_symbol]
+        family_code_instances = filtered_entries(
+            [instance_name(family, instance_args) for instance_args in metadata[:family]],
+            code_instances,
+        )
         family_decoders = filtered_entries(metadata[:decoders], decoders)
         family_setups = filtered_entries(metadata[:setups], setups)
 
-        for decoder in family_decoders
-            for setup in family_setups
-                push!(expanded, Dict(
-                    "family" => family,
-                    "decoder" => manifest_name(decoder),
-                    "setup" => manifest_name(setup),
-                ))
+        if split_code_instances
+            for code_instance in family_code_instances
+                for decoder in family_decoders
+                    for setup in family_setups
+                        push!(expanded, Dict(
+                            "family" => family,
+                            "code_instance" => code_instance,
+                            "decoder" => manifest_name(decoder),
+                            "setup" => manifest_name(setup),
+                        ))
+                    end
+                end
+            end
+        else
+            for decoder in family_decoders
+                for setup in family_setups
+                    push!(expanded, Dict(
+                        "family" => family,
+                        "decoder" => manifest_name(decoder),
+                        "setup" => manifest_name(setup),
+                    ))
+                end
             end
         end
     end
@@ -164,9 +212,10 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
     for (index, task_name) in enumerate(task_names)
         task = normalized_task(task_name)
         family = task["family"]
+        code_instance = get(task, "code_instance", nothing)
         decoder = get(task, "decoder", nothing)
         setup = get(task, "setup", nothing)
-        id = isnothing(decoder) && isnothing(setup) ? task_id(index, family) : task_id(index, family, decoder, setup)
+        id = all(isnothing, (code_instance, decoder, setup)) ? task_id(index, family) : task_id(index, family, code_instance, decoder, setup)
         uuid = string(uuid4())
         filename = db_filename(uuid)
         task_manifest = Dict(
@@ -180,8 +229,9 @@ function build_slurm_manifest(task_names; run_root="runs/slurm", run_id=default_
             "status_path" => joinpath(status_dir, "$(id).toml"),
         )
 
-        haskey(task, "decoder") && (task_manifest["decoder"] = task["decoder"])
-        haskey(task, "setup") && (task_manifest["setup"] = task["setup"])
+        for field in TASK_DETAIL_FIELDS
+            haskey(task, field) && (task_manifest[field] = task[field])
+        end
 
         push!(tasks, task_manifest)
     end

--- a/script/slurm/slurm_manifest_generator.jl
+++ b/script/slurm/slurm_manifest_generator.jl
@@ -1,0 +1,329 @@
+#!/usr/bin/env julia
+
+module SlurmManifestGenerator
+
+using Dates
+using TOML
+
+# ---------------------------------------------------------------------------
+# Configuration
+#
+# Edit these constants to change the default manifest generation plan.
+# This script only writes a manifest; it does not submit Slurm jobs or run
+# benchmarks.
+# ---------------------------------------------------------------------------
+
+const SCHEMA_VERSION = "1"
+const RUN_ROOT = "run/slurm"
+const RUN_ID = "" # Empty means use a timestamp-based run id.
+
+const LIGHT_FAMILIES = [
+    :Gottesman,
+    :Toric,
+    :Shor9,
+    :Steane7,
+    :Perfect5,
+    :Cleve8,
+    :Surface,
+]
+
+const HEAVY_FAMILIES = [
+    :GeneralizedBicycle,
+    :TwoBlockGroupAlgebra,
+    :Triangular488,
+    :Triangular666,
+]
+
+const INCLUDE_FAMILIES = vcat(LIGHT_FAMILIES, HEAVY_FAMILIES)
+const ERROR_CHUNK_SIZE = 5
+const ALLOW_OVERWRITE = false
+
+Base.@kwdef struct ManifestConfig
+    run_root::String = RUN_ROOT
+    run_id::Union{Nothing,String} = isempty(RUN_ID) ? nothing : RUN_ID
+    include_families::Vector{Symbol} = copy(INCLUDE_FAMILIES)
+    heavy_families::Vector{Symbol} = copy(HEAVY_FAMILIES)
+    error_chunk_size::Int = ERROR_CHUNK_SIZE
+    allow_overwrite::Bool = ALLOW_OVERWRITE
+end
+
+export ManifestConfig,
+    artifact_paths,
+    build_manifest,
+    chunk_ranges,
+    default_run_id,
+    main,
+    planned_nsamples,
+    validate_manifest!,
+    write_manifest_file
+
+timestamp_utc(t=now(UTC)) = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SS") * "Z"
+default_run_id(t=now(UTC)) = "slurm_" * Dates.format(t, dateformat"yyyymmdd_HHMMSS")
+resolved_run_id(config::ManifestConfig) = isnothing(config.run_id) || isempty(config.run_id) ? default_run_id() : config.run_id
+
+"""
+Split a collection of items into contiguous chunks of a specified size, returning the index ranges for each chunk. 
+"""
+function chunk_ranges(nitems::Integer, chunk_size::Integer)
+    chunk_size > 0 || throw(ArgumentError("error_chunk_size must be positive; got $chunk_size"))
+    nitems >= 0 || throw(ArgumentError("nitems must be nonnegative; got $nitems"))
+
+    ranges = UnitRange{Int}[]
+    first_index = 1
+    while first_index <= nitems
+        last_index = min(first_index + chunk_size - 1, nitems)
+        push!(ranges, first_index:last_index)
+        first_index = last_index + 1
+    end
+    return ranges
+end
+
+function artifact_paths(run_root::AbstractString, run_id::AbstractString)
+    run_dir = joinpath(run_root, run_id)
+    return Dict{String,Any}(
+        "run_dir" => run_dir,
+        "manifest" => joinpath(run_dir, "manifest.toml"),
+        "db_dir" => joinpath(run_dir, "db"),
+        "log_dir" => joinpath(run_dir, "logs"),
+        "status_dir" => joinpath(run_dir, "status"),
+        "failure_report" => joinpath(run_dir, "failures.toml"),
+        "merged_db" => joinpath(run_dir, "merged_results.sqlite"),
+    )
+end
+
+# Keep manifest sample planning aligned with the current benchmark pass without
+# loading the benchmark module and its runtime dependencies.
+planned_nsamples(error_rate::Real) = get(ENV, "ECCBENCHWIKI_QUICKCHECK", "") == "" ? Int(ceil(40 / error_rate)) : 10
+
+default_family_name(family) = family isa Symbol ? string(family) : string(nameof(family))
+default_object_name(x) = string(x)
+manifest_value(x) = string(x)
+
+function errrange_values(errrange)
+    errmin, errmax, steps = errrange
+    steps > 0 || throw(ArgumentError("errrange steps must be positive; got $steps"))
+    errmin > 0 || throw(ArgumentError("errrange minimum must be positive; got $errmin"))
+    errmax > 0 || throw(ArgumentError("errrange maximum must be positive; got $errmax"))
+    return collect(exp.(range(log(errmin), log(errmax), length=steps)))
+end
+
+function family_lookup(code_metadata; family_name_fn=default_family_name)
+    lookup = Dict{Symbol,Any}()
+    for family in keys(code_metadata)
+        name = Symbol(family_name_fn(family))
+        haskey(lookup, name) && error("duplicate code family name in metadata: $name")
+        lookup[name] = family
+    end
+    return lookup
+end
+
+function tuple_display(args)
+    values = string.(collect(args))
+    isempty(values) && return "()"
+    suffix = length(values) == 1 ? "," : ""
+    return "(" * join(values, ", ") * suffix * ")"
+end
+
+function task_artifacts(paths, task_id)
+    return Dict{String,Any}(
+        "db" => joinpath(paths["db_dir"], "$task_id.sqlite"),
+        "log" => joinpath(paths["log_dir"], "$task_id.log"),
+        "status" => joinpath(paths["status_dir"], "$task_id.toml"),
+        "failure" => joinpath(paths["status_dir"], "$task_id.failure.toml"),
+    )
+end
+
+function build_tasks(code_metadata, config::ManifestConfig, paths;
+    family_name_fn=default_family_name,
+    object_name_fn=default_object_name,
+)
+    config.error_chunk_size > 0 || throw(ArgumentError("error_chunk_size must be positive; got $(config.error_chunk_size)"))
+
+    lookup = family_lookup(code_metadata; family_name_fn)
+    missing_families = setdiff(config.include_families, collect(keys(lookup)))
+    isempty(missing_families) || error("unknown code families in include_families: $(join(string.(missing_families), ", "))")
+
+    tasks = Dict{String,Any}[]
+    task_index = 0
+    heavy = Set(config.heavy_families)
+
+    for family_symbol in config.include_families
+        family = lookup[family_symbol]
+        metadata = code_metadata[family]
+        family_name = string(family_symbol)
+        errrange = metadata[:errrange]
+        errors = errrange_values(errrange)
+        ranges = chunk_ranges(length(errors), config.error_chunk_size)
+        weight_class = family_symbol in heavy ? "heavy" : "light"
+
+        for (family_index, family_args) in enumerate(metadata[:family])
+            code_instance = family_name * tuple_display(family_args)
+            for (decoder_index, decoder) in enumerate(metadata[:decoders])
+                for (setup_index, setup) in enumerate(metadata[:setups])
+                    for (chunk_index, error_range) in enumerate(ranges)
+                        task_index += 1
+                        task_id = "task_" * lpad(string(task_index), 6, "0")
+                        chunk_errors = errors[error_range]
+                        push!(tasks, Dict{String,Any}(
+                            "id" => task_id,
+                            "task_index" => task_index,
+                            "weight_class" => weight_class,
+                            "family" => family_name,
+                            "family_index" => family_index,
+                            "family_args" => manifest_value.(collect(family_args)),
+                            "family_args_display" => tuple_display(family_args),
+                            "code_instance" => code_instance,
+                            "decoder_index" => decoder_index,
+                            "decoder" => string(object_name_fn(decoder)),
+                            "setup_index" => setup_index,
+                            "setup" => string(object_name_fn(setup)),
+                            "error_chunk_index" => chunk_index,
+                            "error_indices" => collect(error_range),
+                            "errors" => Float64.(chunk_errors),
+                            "planned_nsamples" => planned_nsamples.(chunk_errors),
+                            "artifacts" => task_artifacts(paths, task_id),
+                        ))
+                    end
+                end
+            end
+        end
+    end
+
+    validate_unique!(getindex.(tasks, "id"), "task id")
+    for artifact_name in ("db", "log", "status", "failure")
+        validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
+    end
+    return tasks
+end
+
+function validate_unique!(values, label)
+    seen = Set{Any}()
+    duplicates = Any[]
+    for value in values
+        if value in seen
+            push!(duplicates, value)
+        end
+        push!(seen, value)
+    end
+    isempty(duplicates) || error("duplicate $label values: $(join(string.(unique(duplicates)), ", "))")
+    return values
+end
+
+function maybe_command_output(cmd::Cmd)
+    try
+        value = chomp(read(cmd, String))
+        return isempty(value) ? nothing : value
+    catch
+        return nothing
+    end
+end
+
+function git_metadata(repo_root=pwd())
+    metadata = Dict{String,Any}("available" => false)
+    commit = maybe_command_output(`git -C $repo_root rev-parse HEAD`)
+    isnothing(commit) && return metadata
+
+    branch = maybe_command_output(`git -C $repo_root branch --show-current`)
+    remote = maybe_command_output(`git -C $repo_root config --get remote.origin.url`)
+    dirty_status = maybe_command_output(`git -C $repo_root status --short`)
+
+    metadata["available"] = true
+    metadata["commit"] = commit
+    metadata["branch"] = isnothing(branch) ? "" : branch
+    metadata["remote"] = isnothing(remote) ? "" : remote
+    metadata["dirty"] = !isnothing(dirty_status)
+    return metadata
+end
+
+function build_manifest(code_metadata, config::ManifestConfig=ManifestConfig();
+    generated_at=timestamp_utc(),
+    repo_root=pwd(),
+    include_git=true,
+    family_name_fn=default_family_name,
+    object_name_fn=default_object_name,
+)
+    run_id = resolved_run_id(config)
+    paths = artifact_paths(config.run_root, run_id)
+    tasks = build_tasks(code_metadata, config, paths; family_name_fn, object_name_fn)
+
+    manifest = Dict{String,Any}(
+        "schema_version" => SCHEMA_VERSION,
+        "generated_at" => generated_at,
+        "run" => Dict{String,Any}(
+            "id" => run_id,
+            "root" => config.run_root,
+        ),
+        "config" => Dict{String,Any}(
+            "include_families" => string.(config.include_families),
+            "heavy_families" => string.(config.heavy_families),
+            "error_chunk_size" => config.error_chunk_size,
+            "allow_overwrite" => config.allow_overwrite,
+        ),
+        "artifacts" => paths,
+        "git" => include_git ? git_metadata(repo_root) : Dict{String,Any}("available" => false),
+        "tasks" => tasks,
+    )
+    validate_manifest!(manifest)
+    return manifest
+end
+
+function validate_manifest!(manifest)
+    tasks = manifest["tasks"]
+    validate_unique!(getindex.(tasks, "id"), "task id")
+    for artifact_name in ("db", "log", "status", "failure")
+        validate_unique!([task["artifacts"][artifact_name] for task in tasks], "$artifact_name artifact path")
+    end
+    return manifest
+end
+
+function write_manifest_file(manifest; allow_overwrite=false)
+    paths = manifest["artifacts"]
+    run_dir = paths["run_dir"]
+    if isdir(run_dir) && !allow_overwrite
+        error("run directory already exists: $run_dir; set ALLOW_OVERWRITE = true to write into it")
+    end
+
+    mkpath(run_dir)
+    mkpath(paths["db_dir"])
+    mkpath(paths["log_dir"])
+    mkpath(paths["status_dir"])
+
+    manifest_path = paths["manifest"]
+    open(manifest_path, "w") do io
+        TOML.print(io, manifest)
+    end
+    return manifest_path
+end
+
+function load_project_metadata(repo_root=pwd())
+    include(joinpath(repo_root, "_0.helpers_and_metadata", "helpers.jl"))
+    include(joinpath(repo_root, "_0.helpers_and_metadata", "code_metadata.jl"))
+    return (
+        code_metadata=CodeMetadata.code_metadata,
+        family_name_fn=Helpers.typenameof,
+        object_name_fn=Helpers.skipredundantfix,
+    )
+end
+
+function main()
+    repo_root = abspath(joinpath(@__DIR__, ".."))
+    project = load_project_metadata(repo_root)
+    config = ManifestConfig()
+    manifest = build_manifest(
+        project.code_metadata,
+        config;
+        repo_root,
+        family_name_fn=project.family_name_fn,
+        object_name_fn=project.object_name_fn,
+    )
+    manifest_path = write_manifest_file(manifest; allow_overwrite=config.allow_overwrite)
+    println("Wrote Slurm run manifest: $manifest_path")
+    println("Planned tasks: $(length(manifest["tasks"]))")
+    return manifest_path
+end
+
+end # module
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    SlurmManifestGenerator.main()
+end

--- a/wiki_database_passes.jl
+++ b/wiki_database_passes.jl
@@ -8,7 +8,6 @@ global_logger(TerminalLogger(right_justify=120))
 
 include("_0.helpers_and_metadata/helpers.jl")
 include("_0.helpers_and_metadata/db_helpers.jl")
-include("_0.helpers_and_metadata/slurm_helper.jl")
 
 using .Helpers: logrange, instancenameof, skipredundantfix
 using .DBHelpers: dbrow, dbnarray, dbrow!, init_db!
@@ -28,16 +27,11 @@ using .CodeMarkdown: prep_markdown
 
 #
 
-function run_evaluations(code_metadata; include=nothing, worker_db=false, db_path="codes/", db_filename=nothing)
-    if !worker_db
-        if isnothing(db_filename)
-            init_db!(db_path)
-        else
-            init_db!(db_path; filename=db_filename)
-        end
+function run_evaluations(code_metadata; include=nothing, db_path="codes/", db_filename=nothing)
+    if isnothing(db_filename)
+        init_db!(db_path)
     else
-        filename = isnothing(db_filename) ? generate_unique_name() : db_filename
-        init_db!(db_path; filename)
+        init_db!(db_path; filename=db_filename)
     end
     for (codetype, metadata) in code_metadata
         codetypename = typenameof(codetype)

--- a/wiki_database_passes.jl
+++ b/wiki_database_passes.jl
@@ -27,7 +27,23 @@ using .CodeMarkdown: prep_markdown
 
 #
 
-function run_evaluations(code_metadata; include=nothing, db_path="codes/", db_filename=nothing)
+filter_items(filters::AbstractString) = (filters,)
+filter_items(filters::AbstractVector) = filters
+filter_items(filters::Tuple) = filters
+filter_items(filters) = (filters,)
+
+function matches_filter(entry, filter)
+    entry == filter && return true
+    return skipredundantfix(entry) == skipredundantfix(filter)
+end
+
+function filtered_entries(entries, filters)
+    isnothing(filters) && return entries
+    selected = filter_items(filters)
+    return [entry for entry in entries if any(filter -> matches_filter(entry, filter), selected)]
+end
+
+function run_evaluations(code_metadata; include=nothing, decoders=nothing, setups=nothing, db_path="codes/", db_filename=nothing)
     if isnothing(db_filename)
         init_db!(db_path)
     else
@@ -37,12 +53,13 @@ function run_evaluations(code_metadata; include=nothing, db_path="codes/", db_fi
         codetypename = typenameof(codetype)
         !isnothing(include) && codetype ∉ include && continue
         codes = [codetype(instance_args...) for instance_args in metadata[:family]]
-        decoders = metadata[:decoders]
-        setups = metadata[:setups]
+        family_decoders = filtered_entries(metadata[:decoders], decoders)
+        family_setups = filtered_entries(metadata[:setups], setups)
+        (isempty(family_decoders) || isempty(family_setups)) && continue
         errrange = metadata[:errrange]
         @info "Evaluating $(codetypename) ..."
         warn = !get(metadata, :redundantrows, false)
-        e, n, r = evaluate_codes_decoders_setups(codes, decoders, setups; errrange, warn)
+        e, n, r = evaluate_codes_decoders_setups(codes, family_decoders, family_setups; errrange, warn)
     end
 end
 

--- a/wiki_database_passes.jl
+++ b/wiki_database_passes.jl
@@ -28,11 +28,16 @@ using .CodeMarkdown: prep_markdown
 
 #
 
-function run_evaluations(code_metadata; include=nothing, worker_db=false, db_path="codes/")
+function run_evaluations(code_metadata; include=nothing, worker_db=false, db_path="codes/", db_filename=nothing)
     if !worker_db
-        init_db!(db_path)
+        if isnothing(db_filename)
+            init_db!(db_path)
+        else
+            init_db!(db_path; filename=db_filename)
+        end
     else
-        init_db!(db_path; filename=generate_unique_name())
+        filename = isnothing(db_filename) ? generate_unique_name() : db_filename
+        init_db!(db_path; filename)
     end
     for (codetype, metadata) in code_metadata
         codetypename = typenameof(codetype)

--- a/wiki_database_passes.jl
+++ b/wiki_database_passes.jl
@@ -43,7 +43,38 @@ function filtered_entries(entries, filters)
     return [entry for entry in entries if any(filter -> matches_filter(entry, filter), selected)]
 end
 
-function run_evaluations(code_metadata; include=nothing, decoders=nothing, setups=nothing, db_path="codes/", db_filename=nothing)
+function code_instance_name(codetype, instance_args)
+    args = instance_args isa Tuple ? instance_args : (instance_args,)
+    return "$(typenameof(codetype))($(join(string.(args), ", ")))"
+end
+
+function code_instance_filter_name(codetype, filter)
+    filter isa AbstractString && return filter
+    filter isa Tuple && return code_instance_name(codetype, filter)
+
+    try
+        return instancenameof(filter)
+    catch
+        return filter
+    end
+end
+
+function matches_code_instance_filter(codetype, instance_args, filter)
+    instance_name = code_instance_name(codetype, instance_args)
+    instance_name == filter && return true
+    return skipredundantfix(instance_name) == skipredundantfix(code_instance_filter_name(codetype, filter))
+end
+
+function filtered_code_instance_args(codetype, instance_args_list, filters)
+    isnothing(filters) && return instance_args_list
+    selected = filter_items(filters)
+    return [
+        instance_args for instance_args in instance_args_list
+        if any(filter -> matches_code_instance_filter(codetype, instance_args, filter), selected)
+    ]
+end
+
+function run_evaluations(code_metadata; include=nothing, code_instances=nothing, decoders=nothing, setups=nothing, db_path="codes/", db_filename=nothing)
     if isnothing(db_filename)
         init_db!(db_path)
     else
@@ -52,10 +83,11 @@ function run_evaluations(code_metadata; include=nothing, decoders=nothing, setup
     for (codetype, metadata) in code_metadata
         codetypename = typenameof(codetype)
         !isnothing(include) && codetype ∉ include && continue
-        codes = [codetype(instance_args...) for instance_args in metadata[:family]]
+        instance_args_list = filtered_code_instance_args(codetype, metadata[:family], code_instances)
+        codes = [codetype(instance_args...) for instance_args in instance_args_list]
         family_decoders = filtered_entries(metadata[:decoders], decoders)
         family_setups = filtered_entries(metadata[:setups], setups)
-        (isempty(family_decoders) || isempty(family_setups)) && continue
+        (isempty(codes) || isempty(family_decoders) || isempty(family_setups)) && continue
         errrange = metadata[:errrange]
         @info "Evaluating $(codetypename) ..."
         warn = !get(metadata, :redundantrows, false)


### PR DESCRIPTION
# #58 Working Slurm Script

Slurm script that reliably generates enough samples through the QuantumClifford evaluation pipeline. The finished workflow should run several code families and decoders reliably, produce clear per-run artifacts, and report failures in a way that is easy to inspect after an HPC run.

## Changes
- Slurm entry point under `scripts/slurm/slurm.jl`
- Allow flexible run_evaluation() task splits by code family, setup, decoder, and code instances. Slurm script supports different approaches for light/heavy tasks
- Implemented per-job manifest generation, job summary, per-task logs and status files. Artifacts stored under runs/slurm/<job_id>.
- Moved DB join script to `scripts/slurm/get_results.jl`

## Potential future improvements
- Support error rate chunks
- Allow configurable slurm setups e.g. ENV variables to configure heavy worker counts, or allow easier control over task granularity (by code family, decoders, setups, instances)
- One-shot solution that automatically performs join DB step when all tasks succeed

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
